### PR TITLE
Consolidate CI with ci-status-check pattern

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,12 @@
-name: test
+name: ci
 
 on:
-  push:
-    branches: [main]
   pull_request:
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -45,3 +48,12 @@ jobs:
 
       - name: Run bats tests
         run: bats tests/
+
+  ci-status-check:
+    name: CI status check
+    needs: [go-test, bats-test]
+    if: failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - run: exit 1


### PR DESCRIPTION
## Summary

- `test.yml` を `ci.yaml` にリネームし、CI チェックを一本化
- `ci-status-check` ジョブを追加してブランチ保護設定を簡素化
- `push: main` トリガーを削除し `merge_group` を追加
- `concurrency` で同一ブランチの重複実行をキャンセル

## Changes

- `.github/workflows/test.yml` → `.github/workflows/ci.yaml` にリネーム
- ワークフロー名: `test` → `ci`
- トリガー: `push: branches: [main]` + `pull_request` → `pull_request` + `merge_group`
- `concurrency` グループ追加（`cancel-in-progress: true`）
- `ci-status-check` ジョブ追加（`needs: [go-test, bats-test]`、`if: failure()`）

## Branch protection 設定変更（手動対応）

PR マージ後、GitHub のブランチ保護設定で必須チェックを以下の 1 つに変更してください:

- `CI status check` (`ci-status-check`)

個別ジョブ名（`go-test`, `bats-test`）の登録は不要になります。

## 動作確認

- 全ジョブ成功時: `ci-status-check` が skip → GitHub はマージ可と判断
- いずれかのジョブ失敗時: `ci-status-check` が実行され `exit 1` → マージブロック