### PR TITLE
Fix: setupとcleanタスクで実ディレクトリを正しく処理する

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,7 +43,11 @@ tasks:
       - |
         for dir in hooks; do
           if [ -d "{{.TASKFILE_DIR}}/$dir" ]; then
-            ln -sfn "{{.TASKFILE_DIR}}/$dir" "$HOME/.claude/$dir"
+            target="$HOME/.claude/$dir"
+            if [ -d "$target" ] && [ ! -L "$target" ]; then
+              rm -rf "$target"
+            fi
+            ln -sfn "{{.TASKFILE_DIR}}/$dir" "$target"
             echo "  ✓ $dir/"
           fi
         done
@@ -52,7 +56,11 @@ tasks:
         for skill_dir in "{{.TASKFILE_DIR}}/skills"/usadamasa-*/; do
           [ -d "$skill_dir" ] || continue
           skill_name=$(basename "$skill_dir")
-          ln -sfn "$skill_dir" "$HOME/.claude/skills/$skill_name"
+          target="$HOME/.claude/skills/$skill_name"
+          if [ -d "$target" ] && [ ! -L "$target" ]; then
+            rm -rf "$target"
+          fi
+          ln -sfn "$skill_dir" "$target"
           echo "  ✓ skills/$skill_name/"
         done
       - echo "✅ Claude設定をセットアップしました"
@@ -77,11 +85,22 @@ tasks:
     desc: Claude設定の symlink を削除
     cmds:
       - rm -f "$HOME/.claude/CLAUDE.md" "$HOME/.claude/settings.json"
-      - rm -f "$HOME/.claude/hooks"
+      - |
+        target="$HOME/.claude/hooks"
+        if [ -L "$target" ]; then
+          rm -f "$target"
+        elif [ -d "$target" ]; then
+          rm -rf "$target"
+        fi
       - |
         for skill_dir in "{{.TASKFILE_DIR}}/skills"/usadamasa-*/; do
           [ -d "$skill_dir" ] || continue
           skill_name=$(basename "$skill_dir")
-          rm -f "$HOME/.claude/skills/$skill_name"
+          target="$HOME/.claude/skills/$skill_name"
+          if [ -L "$target" ]; then
+            rm -f "$target"
+          elif [ -d "$target" ]; then
+            rm -rf "$target"
+          fi
         done
       - echo "🗑️ Claude設定の symlink を削除しました"

--- a/settings.json
+++ b/settings.json
@@ -147,7 +147,7 @@
       "mcp__plugin_atlassian_atlassian__createConfluencePage"
     ]
   },
-  "model": "claude-opus-4-6[1m]",
+  "model": "opus",
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Summary
- `setup`タスク: `ln -sfn`の前に実ディレクトリ判定(`-d && ! -L`)を追加し、実ディレクトリなら`rm -rf`で削除してからsymlinkを作成
- `clean`タスク: `rm -f`をsymlink/実ディレクトリ両対応に変更(`-L`なら`rm -f`、`-d`なら`rm -rf`)
- `settings.json`: model指定を簡潔な形式に変更

## Test plan
- [x] `task clean`で既存のsymlink/ディレクトリを削除できることを確認
- [x] `task setup`で再セットアップが正常に完了することを確認
- [x] `task status`で全項目✓を確認
- [x] `task test`でbatsテスト10件 + Goテスト3パッケージ全件パスを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)