### PR TITLE
Claude Code環境変数をclaude-configリポジトリで管理する

### DIFF
--- a/.claude/skills/manage-claude-envs/skill.md
+++ b/.claude/skills/manage-claude-envs/skill.md
@@ -1,0 +1,58 @@
+---
+name: manage-claude-envs
+description: >-
+  Claude Code環境変数(env.sh)の管理と最新モデルへの更新を行う。
+  Anthropic公式ドキュメントから最新のVertexモデル名を取得し、
+  env.shとenv.sh.exampleのモデル設定を更新する。
+  「モデルを更新して」「最新モデルに追従」「env更新」「モデル確認」
+  のように依頼されたときに使用する。
+---
+
+# Claude Code 環境変数管理
+
+## 対象ファイル
+
+- `env.sh` - 実際の環境変数ファイル (.gitignore 対象)
+- `env.sh.example` - テンプレート (リポジトリ管理下)
+
+## モデル更新手順
+
+### 1. 現在の設定を確認
+
+`env.sh` を Read して現在のモデル設定を表示する。
+
+### 2. 最新モデルを確認
+
+以下の Anthropic 公式ドキュメントから最新の Claude モデル名を取得する:
+
+- WebFetch: `https://docs.anthropic.com/en/docs/about-claude/models` で最新モデル一覧を取得
+- Vertex AI で利用可能なモデル ID を確認する
+
+### 3. 更新対象の環境変数
+
+以下の環境変数のモデル名を最新に更新する:
+
+| 環境変数 | 用途 |
+|---------|------|
+| `ANTHROPIC_MODEL` | デフォルトモデル (通常 sonnet) |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | haiku 指定時のモデル |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL` | opus 指定時のモデル |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | sonnet 指定時のモデル |
+| `CLAUDE_CODE_SUBAGENT_MODEL` | subagent 用モデル (通常 sonnet) |
+
+### 4. ユーザー確認
+
+差分がある場合、変更内容をユーザーに表示して確認を求める。
+
+### 5. ファイル更新
+
+承認後、`env.sh` と `env.sh.example` の両方を Edit ツールで更新する。
+
+## 初期セットアップ
+
+`env.sh` が存在しない場合:
+
+1. `env.sh.example` を Read する
+2. ユーザーに `ANTHROPIC_VERTEX_PROJECT_ID` を確認する
+3. 値を埋めて `env.sh` を Write する
+4. `task setup` で symlink を作成するよう案内する

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ stats-cache.json
 /security_warnings_state_*.json
 /agent-memory
 /debug
+/env.sh

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,7 +33,7 @@ tasks:
       - mkdir -p "$HOME/.claude/skills"
       # トップレベルファイルの symlink
       - |
-        for file in CLAUDE.md settings.json; do
+        for file in CLAUDE.md settings.json env.sh; do
           if [ -f "{{.TASKFILE_DIR}}/$file" ]; then
             ln -sfn "{{.TASKFILE_DIR}}/$file" "$HOME/.claude/$file"
             echo "  ✓ $file"
@@ -74,6 +74,7 @@ tasks:
         echo "  CLAUDE.md: $(test -L "$HOME/.claude/CLAUDE.md" && echo '✓' || echo '✗')"
         echo "  settings.json: $(test -L "$HOME/.claude/settings.json" && echo '✓' || echo '✗')"
         echo "  hooks: $(test -L "$HOME/.claude/hooks" && echo '✓' || echo '✗')"
+        echo "  env.sh: $(test -L "$HOME/.claude/env.sh" && echo '✓' || echo '✗')"
         echo "  skills:"
         for skill_dir in "{{.TASKFILE_DIR}}/skills"/*/; do
           [ -d "$skill_dir" ] || continue
@@ -84,7 +85,7 @@ tasks:
   clean:
     desc: Claude設定の symlink を削除
     cmds:
-      - rm -f "$HOME/.claude/CLAUDE.md" "$HOME/.claude/settings.json"
+      - rm -f "$HOME/.claude/CLAUDE.md" "$HOME/.claude/settings.json" "$HOME/.claude/env.sh"
       - |
         target="$HOME/.claude/hooks"
         if [ -L "$target" ]; then

--- a/env.sh.example
+++ b/env.sh.example
@@ -1,0 +1,15 @@
+# Claude Code Vertex AI 設定
+export CLAUDE_CODE_USE_VERTEX=1
+export ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project-id
+export CLOUD_ML_REGION=us-east5
+export DISABLE_PROMPT_CACHING=true
+export DISABLE_AUTOUPDATER=true
+export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+export CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1
+
+# Claude Code モデル設定
+export ANTHROPIC_MODEL="claude-sonnet-4-6"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="claude-haiku-4-5"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="claude-opus-4-6"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="claude-sonnet-4-6"
+export CLAUDE_CODE_SUBAGENT_MODEL="claude-sonnet-4-6"


### PR DESCRIPTION
## Summary
- `env.sh.example` テンプレートを追加し、`env.sh` を `.gitignore` に追加
- `Taskfile.yml` の setup/status/clean タスクに `env.sh` の symlink 管理を追加
- `manage-claude-envs` skill を追加(モデル更新の一元管理用)

## Test plan
- [ ] `task setup` で `env.sh` が `~/.claude/env.sh` に symlink されることを確認
- [ ] `task status` で `env.sh: ✓` が表示されることを確認
- [ ] `task clean` で `env.sh` の symlink が削除されることを確認
- [ ] `/skills` で `manage-claude-envs` が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)