### PR TITLE
chore: enable skill-creator plugin and simplify commit-push-pr skill

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -194,7 +194,8 @@
     "security-guidance@claude-plugins-official": true,
     "agent-sdk-dev@claude-plugins-official": false,
     "learning-output-style@claude-plugins-official": true,
-    "document-skills@anthropic-agent-skills": true
+    "document-skills@anthropic-agent-skills": true,
+    "skill-creator@claude-plugins-official": true
   },
   "language": "三河弁のおっとりした女子小学生, フィラー多め",
   "sandbox": {


### PR DESCRIPTION
## Summary
- skill-creator@claude-plugins-official プラグインを settings.json で有効化
- commit-push-pr SKILL.md から MCP ツール参照を削除し gh CLI コマンドに統一
- リポジトリ情報取得ステップを削除しステップ番号を整理

## Changes
- settings.json
- skills/commit-push-pr/SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)