### PR TITLE
feat: worktree memory seeding & Claude Code hook integration

### DIFF
--- a/hooks/worktree-create.sh
+++ b/hooks/worktree-create.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# worktree-create.sh
+# Claude Code WorktreeCreate フック
+# stdin JSON から name, cwd を読み取り、git wt で worktree を作成し、メモリをロードする
+#
+# stdin: {"name": "branch-name", "cwd": "/path/to/repo"}
+# stdout: worktree パス (Claude Code が cd する先)
+
+set -euo pipefail
+
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+
+# 前提コマンドチェック
+if ! command -v jq &>/dev/null; then
+  echo "ERROR: jq is required" >&2
+  exit 1
+fi
+
+# stdin から JSON を読み取り
+INPUT=$(cat)
+NAME=$(echo "$INPUT" | jq -r '.name // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+
+# git wt で worktree 作成 (--nocd でディレクトリ移動なし、パスのみ出力)
+WORKTREE_PATH=$(cd "$CWD" && git wt --nocd "$NAME")
+if [ -z "$WORKTREE_PATH" ]; then
+  echo "ERROR: git wt failed" >&2
+  exit 1
+fi
+
+# メモリロード (失敗しても続行)
+"$SCRIPT_DIR/worktree-memory-load.sh" "$WORKTREE_PATH" || true
+
+# stdout に worktree パスを出力
+echo "$WORKTREE_PATH"

--- a/hooks/worktree-memory-load.sh
+++ b/hooks/worktree-memory-load.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# worktree-memory-load.sh
+# worktree 作成時に親リポジトリの Claude Code auto-memory を worktree にコピーする
+#
+# Usage: worktree-memory-load.sh <worktree-path>
+
+set -euo pipefail
+
+WORKTREE_PATH="${1:-}"
+if [ -z "$WORKTREE_PATH" ]; then exit 0; fi
+
+# .git がファイルかどうか確認 (worktree 判定)
+GIT_FILE="$WORKTREE_PATH/.git"
+[ -f "$GIT_FILE" ] || exit 0
+
+# gitdir パスを取得
+GIT_DIR=$(sed 's/^gitdir: //' "$GIT_FILE" | tr -d '\n')
+[ -d "$GIT_DIR" ] || exit 0
+
+# commondir ファイルから親 .git ディレクトリを特定
+COMMON_DIR_FILE="$GIT_DIR/commondir"
+[ -f "$COMMON_DIR_FILE" ] || exit 0
+
+COMMON_REL=$(tr -d '\n' < "$COMMON_DIR_FILE")
+
+# 相対パスを絶対パスに変換
+if [[ "$COMMON_REL" == /* ]]; then
+  COMMON_ABS="$COMMON_REL"
+else
+  COMMON_ABS="$(cd "$GIT_DIR" && cd "$COMMON_REL" && pwd)"
+fi
+
+PARENT_ROOT="$(dirname "$COMMON_ABS")"
+
+# パスエンコード: Claude Code の auto-memory パス命名規則に合わせる
+# / . _ を - に変換 (先頭 / も - になる)
+encode_path() { echo "$1" | tr '/._' '-'; }
+
+WORKTREE_ENC=$(encode_path "$WORKTREE_PATH")
+PARENT_ENC=$(encode_path "$PARENT_ROOT")
+
+WORKTREE_MEM="$HOME/.claude/projects/$WORKTREE_ENC/memory"
+PARENT_MEM="$HOME/.claude/projects/$PARENT_ENC/memory"
+
+# 親 memory ディレクトリが存在しない場合はスキップ
+[ -d "$PARENT_MEM" ] || exit 0
+
+# 親 memory が空の場合はスキップ
+# shellcheck disable=SC2012
+[ -n "$(ls -A "$PARENT_MEM" 2>/dev/null)" ] || exit 0
+
+# worktree memory ディレクトリを自動作成
+mkdir -p "$WORKTREE_MEM"
+
+# 親 memory の全ファイルを worktree にコピー
+cp "$PARENT_MEM/"* "$WORKTREE_MEM/"

--- a/hooks/worktree-memory-save.sh
+++ b/hooks/worktree-memory-save.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# migrate-worktree-memory.sh
+# worktree-memory-save.sh
 # worktree 削除前に Claude Code auto-memory を親リポジトリの memory パスに移行する
 #
-# Usage: migrate-worktree-memory.sh <worktree-path>
+# Usage: worktree-memory-save.sh <worktree-path>
 #        または環境変数 GIT_WT_WORKTREE_PATH
 
 set -euo pipefail

--- a/hooks/worktree-remove.sh
+++ b/hooks/worktree-remove.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# worktree-remove.sh
+# Claude Code WorktreeRemove フック
+# stdin JSON から worktree_path を読み取り、メモリをセーブしてから worktree を削除する
+#
+# stdin: {"worktree_path": "/path/to/worktree"}
+# 注意: git wt -d は使わない (dotfile の wt.deletehook との依存を避ける)
+
+set -euo pipefail
+
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+
+# 前提コマンドチェック
+if ! command -v jq &>/dev/null; then
+  echo "ERROR: jq is required" >&2
+  exit 1
+fi
+
+# stdin から JSON を読み取り
+INPUT=$(cat)
+WORKTREE_PATH=$(echo "$INPUT" | jq -r '.worktree_path // empty')
+
+if [ -z "$WORKTREE_PATH" ]; then
+  echo "ERROR: worktree_path is required" >&2
+  exit 1
+fi
+
+# メモリセーブ (失敗しても続行)
+"$SCRIPT_DIR/worktree-memory-save.sh" "$WORKTREE_PATH" || true
+
+# worktree 削除
+if ! git worktree remove "$WORKTREE_PATH" 2>/dev/null; then
+  # 失敗時は --force でリトライ
+  git worktree remove --force "$WORKTREE_PATH"
+  git worktree prune
+fi

--- a/settings.json
+++ b/settings.json
@@ -159,6 +159,26 @@
           }
         ]
       }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/worktree-create.sh"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/worktree-remove.sh"
+          }
+        ]
+      }
     ]
   },
   "statusLine": {

--- a/tests/worktree-create.bats
+++ b/tests/worktree-create.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# worktree-create.sh のテスト
+
+SCRIPT_PATH="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/hooks/worktree-create.sh"
+
+setup() {
+  TEST_TMPDIR=$(mktemp -d)
+  MOCK_BIN="$TEST_TMPDIR/bin"
+  mkdir -p "$MOCK_BIN"
+
+  # git wt のモック (デフォルト: 成功)
+  MOCK_WORKTREE_PATH="$TEST_TMPDIR/worktrees/test-repo/my-branch"
+  mkdir -p "$MOCK_WORKTREE_PATH"
+  # worktree 判定用に .git ファイルを作成
+  echo "gitdir: /tmp/fake-gitdir" > "$MOCK_WORKTREE_PATH/.git"
+
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+if [ "$1" = "wt" ]; then
+  shift
+  # --nocd フラグの確認
+  if [ "$1" = "--nocd" ]; then
+    shift
+    echo "$MOCK_WORKTREE_PATH"
+    exit 0
+  fi
+  echo "$MOCK_WORKTREE_PATH"
+  exit 0
+fi
+# 他の git コマンドは本物を使う
+/usr/bin/git "$@"
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  # worktree-memory-load.sh のモック
+  cat > "$MOCK_BIN/worktree-memory-load.sh" << 'MOCKEOF'
+#!/bin/bash
+echo "LOAD_CALLED: $1" >> "$TEST_TMPDIR/load-calls.log"
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/worktree-memory-load.sh"
+
+  export TEST_TMPDIR MOCK_BIN MOCK_WORKTREE_PATH
+  export PATH="$MOCK_BIN:$PATH"
+  # SCRIPT_DIR を MOCK_BIN に向けて worktree-memory-load.sh のモックを使う
+  export SCRIPT_DIR="$MOCK_BIN"
+}
+
+teardown() {
+  [ -n "$TEST_TMPDIR" ] && rm -rf "$TEST_TMPDIR"
+  unset SCRIPT_DIR
+}
+
+# =============================================================================
+# 前提条件チェック
+# =============================================================================
+
+@test "jq 未インストール: エラー終了" {
+  # jq がない最小限の PATH で実行
+  run env PATH="/usr/bin:/bin:$MOCK_BIN" SCRIPT_DIR="$MOCK_BIN" \
+    bash "$SCRIPT_PATH" <<< '{"name":"test","cwd":"/tmp"}'
+
+  [ "$status" -ne 0 ]
+}
+
+@test "git-wt 未インストール: エラー終了" {
+  # git wt が失敗するモック
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+if [ "$1" = "wt" ]; then
+  echo "git: 'wt' is not a git command" >&2
+  exit 1
+fi
+/usr/bin/git "$@"
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run bash "$SCRIPT_PATH" <<< "{\"name\":\"test\",\"cwd\":\"$TEST_TMPDIR\"}"
+
+  [ "$status" -ne 0 ]
+}
+
+# =============================================================================
+# 正常系
+# =============================================================================
+
+@test "git wt --nocd が呼ばれ、stdout にパスのみ出力される" {
+  cat > "$MOCK_BIN/git" << MOCKEOF
+#!/bin/bash
+if [ "\$1" = "wt" ]; then
+  shift
+  if [ "\$1" = "--nocd" ]; then
+    echo "$MOCK_WORKTREE_PATH"
+    exit 0
+  fi
+  echo "ERROR: --nocd not passed" >&2
+  exit 1
+fi
+/usr/bin/git "\$@"
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run bash "$SCRIPT_PATH" <<< "{\"name\":\"my-branch\",\"cwd\":\"$TEST_TMPDIR\"}"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == "$MOCK_WORKTREE_PATH" ]]
+}
+
+@test "git wt 失敗時に exit 1" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+if [ "$1" = "wt" ]; then
+  echo "fatal: error" >&2
+  exit 128
+fi
+/usr/bin/git "$@"
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run bash "$SCRIPT_PATH" <<< "{\"name\":\"test\",\"cwd\":\"$TEST_TMPDIR\"}"
+
+  [ "$status" -ne 0 ]
+}
+
+@test "worktree-memory-load.sh が呼ばれる" {
+  run bash "$SCRIPT_PATH" <<< "{\"name\":\"my-branch\",\"cwd\":\"$TEST_TMPDIR\"}"
+
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMPDIR/load-calls.log" ]
+  [[ "$(cat "$TEST_TMPDIR/load-calls.log")" == *"LOAD_CALLED: $MOCK_WORKTREE_PATH"* ]]
+}
+
+@test "load 失敗でも worktree パスは正常に出力される" {
+  # worktree-memory-load.sh が失敗するモック
+  cat > "$MOCK_BIN/worktree-memory-load.sh" << 'MOCKEOF'
+#!/bin/bash
+exit 1
+MOCKEOF
+  chmod +x "$MOCK_BIN/worktree-memory-load.sh"
+
+  run bash "$SCRIPT_PATH" <<< "{\"name\":\"my-branch\",\"cwd\":\"$TEST_TMPDIR\"}"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == "$MOCK_WORKTREE_PATH" ]]
+}

--- a/tests/worktree-memory-load.bats
+++ b/tests/worktree-memory-load.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# worktree-memory-load.sh のテスト
+
+SCRIPT_PATH="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/hooks/worktree-memory-load.sh"
+
+setup() {
+  load 'fixtures/worktree-setup.sh'
+  create_worktree_memory_env
+}
+
+teardown() {
+  cleanup_worktree_memory_env
+}
+
+# =============================================================================
+# 正常系: メモリロード
+# =============================================================================
+
+@test "親 MEMORY.md が存在: worktree memory にコピーされる" {
+  mkdir -p "$PARENT_MEM"
+  echo "# 親の MEMORY" > "$PARENT_MEM/MEMORY.md"
+
+  run bash "$SCRIPT_PATH" "$TEST_WORKTREE"
+
+  [ "$status" -eq 0 ]
+  [ -f "$WORKTREE_MEM/MEMORY.md" ]
+  [[ "$(cat "$WORKTREE_MEM/MEMORY.md")" == *"親の MEMORY"* ]]
+}
+
+@test "親に複数ファイル存在: 全てコピーされる" {
+  mkdir -p "$PARENT_MEM"
+  echo "# MEMORY" > "$PARENT_MEM/MEMORY.md"
+  echo "# DEBUG" > "$PARENT_MEM/debugging.md"
+  echo "# PATTERNS" > "$PARENT_MEM/patterns.md"
+
+  run bash "$SCRIPT_PATH" "$TEST_WORKTREE"
+
+  [ "$status" -eq 0 ]
+  [ -f "$WORKTREE_MEM/MEMORY.md" ]
+  [ -f "$WORKTREE_MEM/debugging.md" ]
+  [ -f "$WORKTREE_MEM/patterns.md" ]
+}
+
+@test "worktree memory ディレクトリ未作成: 自動作成される" {
+  # cleanup the pre-created worktree memory dir
+  rm -rf "$WORKTREE_MEM"
+
+  mkdir -p "$PARENT_MEM"
+  echo "# MEMORY" > "$PARENT_MEM/MEMORY.md"
+
+  run bash "$SCRIPT_PATH" "$TEST_WORKTREE"
+
+  [ "$status" -eq 0 ]
+  [ -d "$WORKTREE_MEM" ]
+  [ -f "$WORKTREE_MEM/MEMORY.md" ]
+}
+
+# =============================================================================
+# スキップケース
+# =============================================================================
+
+@test "引数なし: 正常終了" {
+  run bash "$SCRIPT_PATH"
+
+  [ "$status" -eq 0 ]
+}
+
+@test ".git がディレクトリ (通常 repo): スキップ" {
+  local NORMAL_REPO
+  NORMAL_REPO=$(mktemp -d)
+  mkdir -p "$NORMAL_REPO/.git"
+
+  run bash "$SCRIPT_PATH" "$NORMAL_REPO"
+
+  [ "$status" -eq 0 ]
+  rm -rf "$NORMAL_REPO"
+}
+
+@test "親 memory が存在しない: 何もせず正常終了" {
+  # PARENT_MEM は未作成
+
+  run bash "$SCRIPT_PATH" "$TEST_WORKTREE"
+
+  [ "$status" -eq 0 ]
+  # worktree memory に何もコピーされていないことを確認
+  [ -z "$(ls -A "$WORKTREE_MEM" 2>/dev/null)" ]
+}
+
+@test "親 memory が空: 何もせず正常終了" {
+  mkdir -p "$PARENT_MEM"
+  # PARENT_MEM ディレクトリは存在するが中身は空
+
+  run bash "$SCRIPT_PATH" "$TEST_WORKTREE"
+
+  [ "$status" -eq 0 ]
+  [ -z "$(ls -A "$WORKTREE_MEM" 2>/dev/null)" ]
+}

--- a/tests/worktree-memory-save.bats
+++ b/tests/worktree-memory-save.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
-# migrate-worktree-memory.sh のテスト
+# worktree-memory-save.sh のテスト
 
-SCRIPT_PATH="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/hooks/migrate-worktree-memory.sh"
+SCRIPT_PATH="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/hooks/worktree-memory-save.sh"
 
 setup() {
   load 'fixtures/worktree-setup.sh'

--- a/tests/worktree-remove.bats
+++ b/tests/worktree-remove.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+# worktree-remove.sh のテスト
+
+SCRIPT_PATH="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/hooks/worktree-remove.sh"
+
+setup() {
+  TEST_TMPDIR=$(mktemp -d)
+  MOCK_BIN="$TEST_TMPDIR/bin"
+  mkdir -p "$MOCK_BIN"
+
+  # テスト用 worktree パス
+  MOCK_WORKTREE_PATH="$TEST_TMPDIR/worktrees/test-repo/my-branch"
+  mkdir -p "$MOCK_WORKTREE_PATH"
+
+  # git のモック (デフォルト: worktree remove 成功)
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "worktree" ]; then
+  if [ "$2" = "remove" ]; then
+    exit 0
+  fi
+  if [ "$2" = "prune" ]; then
+    exit 0
+  fi
+fi
+/usr/bin/git "$@"
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  # worktree-memory-save.sh のモック
+  cat > "$MOCK_BIN/worktree-memory-save.sh" << 'MOCKEOF'
+#!/bin/bash
+echo "SAVE_CALLED: $1" >> "$TEST_TMPDIR/save-calls.log"
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/worktree-memory-save.sh"
+
+  export TEST_TMPDIR MOCK_BIN MOCK_WORKTREE_PATH
+  export PATH="$MOCK_BIN:$PATH"
+  export SCRIPT_DIR="$MOCK_BIN"
+}
+
+teardown() {
+  [ -n "$TEST_TMPDIR" ] && rm -rf "$TEST_TMPDIR"
+  unset SCRIPT_DIR
+}
+
+# =============================================================================
+# 前提条件チェック
+# =============================================================================
+
+@test "jq 未インストール: エラー終了" {
+  run env PATH="/usr/bin:/bin:$MOCK_BIN" SCRIPT_DIR="$MOCK_BIN" \
+    bash "$SCRIPT_PATH" <<< "{\"worktree_path\":\"$MOCK_WORKTREE_PATH\"}"
+
+  [ "$status" -ne 0 ]
+}
+
+# =============================================================================
+# 正常系
+# =============================================================================
+
+@test "worktree-memory-save.sh が worktree_path で呼ばれる" {
+  run bash "$SCRIPT_PATH" <<< "{\"worktree_path\":\"$MOCK_WORKTREE_PATH\"}"
+
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMPDIR/save-calls.log" ]
+  [[ "$(cat "$TEST_TMPDIR/save-calls.log")" == *"SAVE_CALLED: $MOCK_WORKTREE_PATH"* ]]
+}
+
+@test "git worktree remove が呼ばれる" {
+  run bash "$SCRIPT_PATH" <<< "{\"worktree_path\":\"$MOCK_WORKTREE_PATH\"}"
+
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMPDIR/git-calls.log" ]
+  [[ "$(cat "$TEST_TMPDIR/git-calls.log")" == *"worktree remove $MOCK_WORKTREE_PATH"* ]]
+}
+
+@test "save 失敗でも git worktree remove は実行される" {
+  # save が失敗するモック
+  cat > "$MOCK_BIN/worktree-memory-save.sh" << 'MOCKEOF'
+#!/bin/bash
+exit 1
+MOCKEOF
+  chmod +x "$MOCK_BIN/worktree-memory-save.sh"
+
+  run bash "$SCRIPT_PATH" <<< "{\"worktree_path\":\"$MOCK_WORKTREE_PATH\"}"
+
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMPDIR/git-calls.log" ]
+  [[ "$(cat "$TEST_TMPDIR/git-calls.log")" == *"worktree remove $MOCK_WORKTREE_PATH"* ]]
+}
+
+@test "worktree remove 失敗時は --force でリトライされる" {
+  # 最初の remove は失敗、--force 付きで成功
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "worktree" ]; then
+  if [ "$2" = "remove" ]; then
+    if [[ "$*" == *"--force"* ]]; then
+      exit 0
+    fi
+    echo "fatal: cannot remove" >&2
+    exit 1
+  fi
+  if [ "$2" = "prune" ]; then
+    exit 0
+  fi
+fi
+/usr/bin/git "$@"
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run bash "$SCRIPT_PATH" <<< "{\"worktree_path\":\"$MOCK_WORKTREE_PATH\"}"
+
+  [ "$status" -eq 0 ]
+  # --force でリトライされたことを確認
+  [[ "$(cat "$TEST_TMPDIR/git-calls.log")" == *"--force"* ]]
+  # prune も呼ばれる
+  [[ "$(cat "$TEST_TMPDIR/git-calls.log")" == *"worktree prune"* ]]
+}


### PR DESCRIPTION
## Summary
- WorktreeCreate/WorktreeRemove フックにより、worktree のメモリライフサイクルを自動管理
- `worktree-memory-load.sh` / `worktree-memory-save.sh` の対称設計でメモリの load/save を実現
- `migrate-worktree-memory.sh` → `worktree-memory-save.sh` にリネーム
- スキル `usadamasa-git-worktree` → `git-worktree` にリネーム、フック統合の文書化

## Test plan
- [x] `bats tests/worktree-memory-load.bats` → 7 tests GREEN
- [x] `bats tests/worktree-memory-save.bats` → 10 tests GREEN (退行なし)
- [x] `bats tests/worktree-create.bats` → 6 tests GREEN
- [x] `bats tests/worktree-remove.bats` → 5 tests GREEN
- [ ] 実際に `claude --worktree test-memory` で新規セッション開始して動作確認
- [ ] worktree セッション終了後、メモリが親に移行されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)