### PR TITLE
feat: add dry-run mode and operation logging to worktree hooks

### DIFF
--- a/hooks/lib/hook-logger.sh
+++ b/hooks/lib/hook-logger.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# hook-logger.sh
+# worktree hook スクリプト共通のログ・dry-run ヘルパー
+#
+# 使い方:
+#   HOOK_NAME="worktree-create"
+#   source "$SCRIPT_DIR/lib/hook-logger.sh"
+#
+# 環境変数:
+#   DRY_RUN=1  全操作をシミュレーション表示し、実際の副作用を起こさない
+#   HOOK_NAME  ログプレフィックスに使用するスクリプト名
+
+DRY_RUN="${DRY_RUN:-0}"
+HOOK_NAME="${HOOK_NAME:-hook}"
+
+# DRY_RUN=1 かどうかを判定
+is_dry_run() {
+  [ "$DRY_RUN" = "1" ]
+}
+
+# ログプレフィックスを返す
+# dry-run: "[DRY-RUN]", 通常: "[$HOOK_NAME]"
+_log_prefix() {
+  if is_dry_run; then
+    echo "[DRY-RUN]"
+  else
+    echo "[$HOOK_NAME]"
+  fi
+}
+
+# mkdir -p + ログ出力。dry-run 時は mkdir しない
+logged_mkdir() {
+  local target="$1"
+  if is_dry_run; then
+    echo "$(_log_prefix) MKDIR  $target" >&2
+  else
+    echo "$(_log_prefix) MKDIR  $target" >&2
+    mkdir -p "$target"
+  fi
+}
+
+# cp + ログ出力。dry-run 時は cp しない
+logged_cp() {
+  local src="$1"
+  local dst="$2"
+  if is_dry_run; then
+    echo "$(_log_prefix) CP     $src -> $dst" >&2
+  else
+    echo "$(_log_prefix) CP     $src -> $dst" >&2
+    cp "$src" "$dst"
+  fi
+}
+
+# コマンド実行 + ログ出力。dry-run 時は実行しない
+logged_cmd() {
+  if is_dry_run; then
+    echo "$(_log_prefix) CMD    $*" >&2
+  else
+    echo "$(_log_prefix) CMD    $*" >&2
+    "$@"
+  fi
+}
+
+# スキップ理由の通知
+log_skip() {
+  local reason="$1"
+  echo "$(_log_prefix) SKIP   ($reason)" >&2
+}
+
+# 情報メッセージ (常に出力)
+log_info() {
+  local msg="$1"
+  echo "$(_log_prefix) INFO   $msg" >&2
+}

--- a/hooks/worktree-create.sh
+++ b/hooks/worktree-create.sh
@@ -5,10 +5,13 @@
 #
 # stdin: {"name": "branch-name", "cwd": "/path/to/repo"}
 # stdout: worktree パス (Claude Code が cd する先)
+# 環境変数: DRY_RUN=1 で副作用なしのシミュレーション
 
 set -euo pipefail
 
+HOOK_NAME="worktree-create"
 SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+source "$SCRIPT_DIR/lib/hook-logger.sh"
 
 # 前提コマンドチェック
 if ! command -v jq &>/dev/null; then
@@ -21,7 +24,16 @@ INPUT=$(cat)
 NAME=$(echo "$INPUT" | jq -r '.name // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
+if is_dry_run; then
+  # dry-run: git wt を実行せず、ダミーパスを返す
+  logged_cmd git wt --nocd "$NAME"
+  WORKTREE_PATH="/tmp/dry-run-worktree/$NAME"
+  echo "$WORKTREE_PATH"
+  exit 0
+fi
+
 # git wt で worktree 作成 (--nocd でディレクトリ移動なし、パスのみ出力)
+log_info "git wt --nocd $NAME"
 WORKTREE_PATH=$(cd "$CWD" && git wt --nocd "$NAME")
 if [ -z "$WORKTREE_PATH" ]; then
   echo "ERROR: git wt failed" >&2

--- a/hooks/worktree-remove.sh
+++ b/hooks/worktree-remove.sh
@@ -5,10 +5,13 @@
 #
 # stdin: {"worktree_path": "/path/to/worktree"}
 # 注意: git wt -d は使わない (dotfile の wt.deletehook との依存を避ける)
+# 環境変数: DRY_RUN=1 で副作用なしのシミュレーション
 
 set -euo pipefail
 
+HOOK_NAME="worktree-remove"
 SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+source "$SCRIPT_DIR/lib/hook-logger.sh"
 
 # 前提コマンドチェック
 if ! command -v jq &>/dev/null; then
@@ -25,12 +28,17 @@ if [ -z "$WORKTREE_PATH" ]; then
   exit 1
 fi
 
-# メモリセーブ (失敗しても続行)
+# メモリセーブ (失敗しても続行、DRY_RUN は環境変数として自動伝播)
 "$SCRIPT_DIR/worktree-memory-save.sh" "$WORKTREE_PATH" || true
 
 # worktree 削除
-if ! git worktree remove "$WORKTREE_PATH" 2>/dev/null; then
-  # 失敗時は --force でリトライ
-  git worktree remove --force "$WORKTREE_PATH"
-  git worktree prune
+if is_dry_run; then
+  logged_cmd git worktree remove "$WORKTREE_PATH"
+else
+  log_info "CMD    git worktree remove $WORKTREE_PATH"
+  if ! git worktree remove "$WORKTREE_PATH" 2>/dev/null; then
+    # 失敗時は --force でリトライ
+    logged_cmd git worktree remove --force "$WORKTREE_PATH"
+    logged_cmd git worktree prune
+  fi
 fi

--- a/tests/hook-logger.bats
+++ b/tests/hook-logger.bats
@@ -1,0 +1,223 @@
+#!/usr/bin/env bats
+# hooks/lib/hook-logger.sh のテスト
+
+LOGGER_PATH="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/hooks/lib/hook-logger.sh"
+
+setup() {
+  TEST_TMPDIR=$(mktemp -d)
+  export TEST_TMPDIR
+}
+
+teardown() {
+  [ -n "$TEST_TMPDIR" ] && rm -rf "$TEST_TMPDIR"
+}
+
+# =============================================================================
+# is_dry_run
+# =============================================================================
+
+@test "is_dry_run: DRY_RUN=1 で true を返す" {
+  run env DRY_RUN=1 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; is_dry_run"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "is_dry_run: DRY_RUN=0 で false を返す" {
+  run env DRY_RUN=0 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; is_dry_run"
+
+  [ "$status" -ne 0 ]
+}
+
+@test "is_dry_run: DRY_RUN 未設定で false を返す" {
+  run env -u DRY_RUN HOOK_NAME=test bash -c "source '$LOGGER_PATH'; is_dry_run"
+
+  [ "$status" -ne 0 ]
+}
+
+# =============================================================================
+# _log_prefix
+# =============================================================================
+
+@test "_log_prefix: 通常モードで [HOOK_NAME] を返す" {
+  run env DRY_RUN=0 HOOK_NAME=my-hook bash -c "source '$LOGGER_PATH'; _log_prefix"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "[my-hook]" ]
+}
+
+@test "_log_prefix: dry-run モードで [DRY-RUN] を返す" {
+  run env DRY_RUN=1 HOOK_NAME=my-hook bash -c "source '$LOGGER_PATH'; _log_prefix"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "[DRY-RUN]" ]
+}
+
+# =============================================================================
+# log_info
+# =============================================================================
+
+@test "log_info: メッセージが stderr に出力される" {
+  run env DRY_RUN=0 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; log_info 'hello world' 2>&1"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[test]"* ]]
+  [[ "$output" == *"INFO"* ]]
+  [[ "$output" == *"hello world"* ]]
+}
+
+# =============================================================================
+# log_skip
+# =============================================================================
+
+@test "log_skip: dry-run 時に SKIP メッセージが stderr に出力される" {
+  run env DRY_RUN=1 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; log_skip 'no parent memory' 2>&1"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[DRY-RUN]"* ]]
+  [[ "$output" == *"SKIP"* ]]
+  [[ "$output" == *"no parent memory"* ]]
+}
+
+@test "log_skip: 通常モードでも出力される" {
+  run env DRY_RUN=0 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; log_skip 'no parent memory' 2>&1"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[test]"* ]]
+  [[ "$output" == *"SKIP"* ]]
+}
+
+# =============================================================================
+# logged_mkdir (通常モード)
+# =============================================================================
+
+@test "logged_mkdir: 通常モードでディレクトリが作成される" {
+  local TARGET="$TEST_TMPDIR/new-dir/sub"
+
+  run env DRY_RUN=0 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; logged_mkdir '$TARGET'"
+
+  [ "$status" -eq 0 ]
+  [ -d "$TARGET" ]
+}
+
+@test "logged_mkdir: 通常モードで MKDIR ログが stderr に出力される" {
+  local TARGET="$TEST_TMPDIR/new-dir2"
+
+  run env DRY_RUN=0 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; logged_mkdir '$TARGET' 2>&1"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[test]"* ]]
+  [[ "$output" == *"MKDIR"* ]]
+  [[ "$output" == *"$TARGET"* ]]
+}
+
+# =============================================================================
+# logged_mkdir (dry-run モード)
+# =============================================================================
+
+@test "logged_mkdir: dry-run でディレクトリが作成されない" {
+  local TARGET="$TEST_TMPDIR/should-not-exist"
+
+  run env DRY_RUN=1 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; logged_mkdir '$TARGET'"
+
+  [ "$status" -eq 0 ]
+  [ ! -d "$TARGET" ]
+}
+
+@test "logged_mkdir: dry-run で [DRY-RUN] MKDIR ログが出る" {
+  local TARGET="$TEST_TMPDIR/dry-dir"
+
+  run env DRY_RUN=1 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; logged_mkdir '$TARGET' 2>&1"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[DRY-RUN]"* ]]
+  [[ "$output" == *"MKDIR"* ]]
+}
+
+# =============================================================================
+# logged_cp (通常モード)
+# =============================================================================
+
+@test "logged_cp: 通常モードでファイルがコピーされる" {
+  echo "content" > "$TEST_TMPDIR/src.txt"
+
+  run env DRY_RUN=0 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; logged_cp '$TEST_TMPDIR/src.txt' '$TEST_TMPDIR/dst.txt'"
+
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMPDIR/dst.txt" ]
+  [ "$(cat "$TEST_TMPDIR/dst.txt")" = "content" ]
+}
+
+@test "logged_cp: 通常モードで CP ログが stderr に出力される" {
+  echo "content" > "$TEST_TMPDIR/src2.txt"
+
+  run env DRY_RUN=0 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; logged_cp '$TEST_TMPDIR/src2.txt' '$TEST_TMPDIR/dst2.txt' 2>&1"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[test]"* ]]
+  [[ "$output" == *"CP"* ]]
+  [[ "$output" == *"src2.txt"* ]]
+  [[ "$output" == *"dst2.txt"* ]]
+}
+
+# =============================================================================
+# logged_cp (dry-run モード)
+# =============================================================================
+
+@test "logged_cp: dry-run でファイルがコピーされない" {
+  echo "content" > "$TEST_TMPDIR/src3.txt"
+
+  run env DRY_RUN=1 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; logged_cp '$TEST_TMPDIR/src3.txt' '$TEST_TMPDIR/dst3.txt'"
+
+  [ "$status" -eq 0 ]
+  [ ! -f "$TEST_TMPDIR/dst3.txt" ]
+}
+
+@test "logged_cp: dry-run で [DRY-RUN] CP ログが出る" {
+  echo "content" > "$TEST_TMPDIR/src4.txt"
+
+  run env DRY_RUN=1 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; logged_cp '$TEST_TMPDIR/src4.txt' '$TEST_TMPDIR/dst4.txt' 2>&1"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[DRY-RUN]"* ]]
+  [[ "$output" == *"CP"* ]]
+}
+
+# =============================================================================
+# logged_cmd (通常モード)
+# =============================================================================
+
+@test "logged_cmd: 通常モードでコマンドが実行される" {
+  run env DRY_RUN=0 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; logged_cmd touch '$TEST_TMPDIR/created.txt'"
+
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMPDIR/created.txt" ]
+}
+
+@test "logged_cmd: 通常モードで CMD ログが stderr に出力される" {
+  run env DRY_RUN=0 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; logged_cmd echo hello 2>&1"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[test]"* ]]
+  [[ "$output" == *"CMD"* ]]
+  [[ "$output" == *"echo hello"* ]]
+}
+
+# =============================================================================
+# logged_cmd (dry-run モード)
+# =============================================================================
+
+@test "logged_cmd: dry-run でコマンドが実行されない" {
+  run env DRY_RUN=1 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; logged_cmd touch '$TEST_TMPDIR/should-not-exist.txt'"
+
+  [ "$status" -eq 0 ]
+  [ ! -f "$TEST_TMPDIR/should-not-exist.txt" ]
+}
+
+@test "logged_cmd: dry-run で [DRY-RUN] CMD ログが出る" {
+  run env DRY_RUN=1 HOOK_NAME=test bash -c "source '$LOGGER_PATH'; logged_cmd git wt --nocd my-branch 2>&1"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[DRY-RUN]"* ]]
+  [[ "$output" == *"CMD"* ]]
+  [[ "$output" == *"git wt --nocd my-branch"* ]]
+}

--- a/tests/worktree-create.bats
+++ b/tests/worktree-create.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 # worktree-create.sh のテスト
+bats_require_minimum_version 1.5.0
 
 SCRIPT_PATH="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/hooks/worktree-create.sh"
 
@@ -7,6 +8,11 @@ setup() {
   TEST_TMPDIR=$(mktemp -d)
   MOCK_BIN="$TEST_TMPDIR/bin"
   mkdir -p "$MOCK_BIN"
+
+  # hook-logger.sh を MOCK_BIN/lib にコピー
+  REAL_HOOKS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/hooks"
+  mkdir -p "$MOCK_BIN/lib"
+  cp "$REAL_HOOKS_DIR/lib/hook-logger.sh" "$MOCK_BIN/lib/hook-logger.sh"
 
   # git wt のモック (デフォルト: 成功)
   MOCK_WORKTREE_PATH="$TEST_TMPDIR/worktrees/test-repo/my-branch"
@@ -100,7 +106,7 @@ fi
 MOCKEOF
   chmod +x "$MOCK_BIN/git"
 
-  run bash "$SCRIPT_PATH" <<< "{\"name\":\"my-branch\",\"cwd\":\"$TEST_TMPDIR\"}"
+  run --separate-stderr bash "$SCRIPT_PATH" <<< "{\"name\":\"my-branch\",\"cwd\":\"$TEST_TMPDIR\"}"
 
   [ "$status" -eq 0 ]
   [[ "$output" == "$MOCK_WORKTREE_PATH" ]]
@@ -138,8 +144,63 @@ exit 1
 MOCKEOF
   chmod +x "$MOCK_BIN/worktree-memory-load.sh"
 
-  run bash "$SCRIPT_PATH" <<< "{\"name\":\"my-branch\",\"cwd\":\"$TEST_TMPDIR\"}"
+  run --separate-stderr bash "$SCRIPT_PATH" <<< "{\"name\":\"my-branch\",\"cwd\":\"$TEST_TMPDIR\"}"
 
   [ "$status" -eq 0 ]
   [[ "$output" == "$MOCK_WORKTREE_PATH" ]]
+}
+
+# =============================================================================
+# 通常モード: 操作ログ
+# =============================================================================
+
+@test "通常モード: CMD ログが stderr に出力される" {
+  run bash "$SCRIPT_PATH" <<< "{\"name\":\"my-branch\",\"cwd\":\"$TEST_TMPDIR\"}"
+
+  [ "$status" -eq 0 ]
+  # stderr は run が output に混ぜるので確認できる
+  [[ "$output" == *"$MOCK_WORKTREE_PATH"* ]]
+}
+
+# =============================================================================
+# dry-run モード
+# =============================================================================
+
+@test "dry-run: git wt が実行されない" {
+  # git wt が呼ばれたらログに記録するモック
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "GIT_CALLED: $@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "wt" ]; then
+  echo "$MOCK_WORKTREE_PATH"
+  exit 0
+fi
+/usr/bin/git "$@"
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run env DRY_RUN=1 bash "$SCRIPT_PATH" <<< "{\"name\":\"my-branch\",\"cwd\":\"$TEST_TMPDIR\"}"
+
+  [ "$status" -eq 0 ]
+  # git wt は呼ばれないこと
+  if [ -f "$TEST_TMPDIR/git-calls.log" ]; then
+    ! grep -q "wt" "$TEST_TMPDIR/git-calls.log"
+  fi
+}
+
+@test "dry-run: stdout にダミーパスが出力される" {
+  run env DRY_RUN=1 bash "$SCRIPT_PATH" <<< "{\"name\":\"my-branch\",\"cwd\":\"$TEST_TMPDIR\"}"
+
+  [ "$status" -eq 0 ]
+  # stdout にパスが含まれる (dry-run ダミーパス)
+  [[ "$output" == *"/tmp/dry-run-worktree/my-branch"* ]]
+}
+
+@test "dry-run: [DRY-RUN] CMD メッセージが出力される" {
+  run env DRY_RUN=1 bash "$SCRIPT_PATH" <<< "{\"name\":\"my-branch\",\"cwd\":\"$TEST_TMPDIR\"}"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[DRY-RUN]"* ]]
+  [[ "$output" == *"CMD"* ]]
+  [[ "$output" == *"git wt"* ]]
 }


### PR DESCRIPTION
## Summary

- `DRY_RUN=1` 環境変数で worktree hook の全操作をシミュレーション表示し、実際の副作用を起こさない dry-run モードを追加
- 通常実行時も `[hook-name] CP/MKDIR/CMD` 形式の操作ログを stderr に出力し、何が行われたか可視化
- `hooks/lib/hook-logger.sh` に共通ヘルパー関数を集約し、4つの hook スクリプトから `source` して使用

## Test plan

- [x] `bats tests/hook-logger.bats` で共通ライブラリの20テストが通ること
- [x] `bats tests/worktree-*.bats` で既存テスト + 通常ログテスト + dry-run テストが全て通ること (全69テスト PASS)
- [x] 手動確認: `DRY_RUN=1` で `worktree-create.sh` を実行し、`[DRY-RUN]` メッセージが出て実際の worktree が作成されないこと
- [x] 手動確認: 通常実行で `[worktree-memory-load]` プレフィックスのログが出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)