### PR TITLE
fix: unify worktree detection to git rev-parse and add --projects-dir CLI flag

### DIFF
--- a/.claude/skills/claude-config-management/SKILL.md
+++ b/.claude/skills/claude-config-management/SKILL.md
@@ -58,6 +58,20 @@ task clean    # symlink 削除
 
 `.claude/skills/<skill-name>/SKILL.md` を作成。symlink 不要。
 
+## worktree 環境チェック
+
+worktree 環境では symlink 先がメインリポジトリを指すため、`~/.claude/` 配下の symlink を直接編集してはいけない。
+worktree 判定を行い、`$(pwd)/<file>` を使用すること。
+
+```bash
+GIT_DIR=$(git rev-parse --git-dir)
+GIT_COMMON=$(git rev-parse --git-common-dir)
+# GIT_DIR != GIT_COMMON → worktree 環境
+# GIT_DIR == GIT_COMMON → 通常リポジトリ
+```
+
+詳細は CLAUDE.md の「worktree 環境でのファイルパス解決」を参照。
+
 ## 注意事項
 
 - `ln -sfn` でディレクトリ先に既存ディレクトリがあるとネスト symlink が発生する。

--- a/.claude/skills/manage-claude-envs/skill.md
+++ b/.claude/skills/manage-claude-envs/skill.md
@@ -10,7 +10,14 @@ description: >-
 
 # Claude Code 環境変数管理
 
-## 対象ファイル
+### 0. worktree 環境チェック
+
+CLAUDE.md の「worktree 環境でのファイルパス解決」を参照し、worktree 判定を行う。
+worktree 環境の場合、`env.sh` の編集パスを `$(pwd)/env.sh` に読み替えること。
+`env.sh` には `--settings` 相当のフラグがないため、Edit ツールで直接 `$(pwd)/env.sh` を指定する。
+`env.sh.example` は worktree でも通常でも `$(pwd)/env.sh.example` で変更不要。
+
+### 対象ファイル
 
 - `env.sh` - 実際の環境変数ファイル (.gitignore 対象)
 - `env.sh.example` - テンプレート (リポジトリ管理下)

--- a/.claude/skills/permission-optimizer/SKILL.md
+++ b/.claude/skills/permission-optimizer/SKILL.md
@@ -14,12 +14,23 @@ settings.jsonの`permissions.allow`/`permissions.deny`/`permissions.ask`に登�
 
 ## ワークフロー
 
+### 0. worktree 環境チェック
+
+CLAUDE.md の「worktree 環境でのファイルパス解決」を参照し、worktree 判定を行う。
+worktree 環境の場合、以降のステップで settings.json のパスを `$(pwd)/settings.json` に読み替えること。
+
 ### 1. 分析の実行
 
 以下のコマンドを実行してツール使用状況を集計する:
 
+**通常リポジトリ:**
 ```bash
 go run ./cmd/analyze-permissions --days 30
+```
+
+**worktree 環境:**
+```bash
+go run ./cmd/analyze-permissions --days 30 --settings $(pwd)/settings.json --projects-dir ~/.claude/projects
 ```
 
 オプション:

--- a/.claude/skills/webfetch-domain-manager/SKILL.md
+++ b/.claude/skills/webfetch-domain-manager/SKILL.md
@@ -14,12 +14,23 @@ settings.jsonの`permissions.allow`に登録されているWebFetch/Fetchドメ�
 
 ## ワークフロー
 
+### 0. worktree 環境チェック
+
+CLAUDE.md の「worktree 環境でのファイルパス解決」を参照し、worktree 判定を行う。
+worktree 環境の場合、以降のステップで settings.json のパスを `$(pwd)/settings.json` に読み替えること。
+
 ### 1. 分析の実行
 
 以下のコマンドを実行してWebFetch/Fetch使用状況を集計する:
 
+**通常リポジトリ:**
 ```bash
 go run ./cmd/analyze-webfetch --days 30
+```
+
+**worktree 環境:**
+```bash
+go run ./cmd/analyze-webfetch --days 30 --settings $(pwd)/settings.json --projects-dir ~/.claude/projects
 ```
 
 オプション:

--- a/CLAUDE-global.md
+++ b/CLAUDE-global.md
@@ -57,9 +57,13 @@ Before proposing any infrastructure changes, confirm:
 
 git 操作 (commit, push, PR作成など) を行う前に、**必ず以下の環境チェックを実行する**:
 
-1. `cat .git` で worktree 環境かどうかを判定する
-   - ファイルで `gitdir: ...` が返る → **worktree 環境**
-   - ディレクトリとして存在する → 通常のリポジトリ
+1. `git rev-parse` で worktree 環境かどうかを判定する
+   ```bash
+   GIT_DIR=$(git rev-parse --git-dir)
+   GIT_COMMON=$(git rev-parse --git-common-dir)
+   ```
+   - `GIT_DIR != GIT_COMMON` → **worktree 環境**
+   - `GIT_DIR == GIT_COMMON` → 通常のリポジトリ
 2. worktree 環境の場合、`git config --get remote.origin.fetch` を確認する
    - 空なら `git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"` で修正してから `git fetch origin` を実行する
 3. `gh pr create` は worktree + bare 環境では `--head {branch_name}` フラグを付ける

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,50 @@ task go:test # Go テストのみ実行
 - `hooks/` → `~/.claude/hooks/`
 - `skills/*/` → `~/.claude/skills/*/` (各スキルディレクトリを個別リンク)
 
-## worktree 環境での注意事項
+## worktree 環境でのファイルパス解決
 
-このリポジトリは bare リポジトリ + git worktree で運用される場合がある｡
-worktree 環境では `.git` がファイル(ディレクトリではない)になるため､
-`cat .git` で `gitdir:` が返るかどうかで判定する｡
+このリポジトリは通常リポジトリ + git worktree (linked worktree) で運用される場合がある｡
+worktree 環境では symlink 対象ファイルの編集先・参照先が通常と異なるため､
+以下のプロトコルに従うこと｡
+
+### worktree 判定
+
+`git rev-parse` で判定する:
+
+```bash
+GIT_DIR=$(git rev-parse --git-dir)
+GIT_COMMON=$(git rev-parse --git-common-dir)
+# GIT_DIR != GIT_COMMON → worktree 環境
+# GIT_DIR == GIT_COMMON → 通常リポジトリ
+```
+
+### symlink 対象ファイルのパス解決
+
+| ファイル | 通常リポジトリ | worktree 環境 |
+| ---- | ---- | ---- |
+| `settings.json` | `~/.claude/settings.json` | `$(pwd)/settings.json` |
+| `env.sh` | `~/.claude/env.sh` | `$(pwd)/env.sh` |
+| `env.sh.example` | `$(pwd)/env.sh.example` | `$(pwd)/env.sh.example` |
+| `CLAUDE-global.md` | `~/.claude/CLAUDE.md` | `$(pwd)/CLAUDE-global.md` |
+
+### スキル実行時の手順
+
+1. `git rev-parse --git-dir` と `--git-common-dir` を比較して worktree 判定
+2. worktree なら Edit ツールのパスに `$(pwd)/<file>` を使用する
+3. CLI ツール (`analyze-permissions`, `analyze-webfetch`) は worktree なら `--settings $(pwd)/settings.json` を付ける
+
+### 検証フロー
+
+worktree で変更した設定を動作確認するフロー:
+
+```
+1. worktree で settings.json を編集
+2. worktree から `task setup` を実行 → symlink が worktree のファイルを指す
+3. 新しい Claude Code セッションで動作確認
+4. 確認後、メインリポジトリから `task setup` を実行して復元:
+   MAIN_WORKTREE=$(git rev-parse --git-common-dir | xargs dirname)
+   (cd "$MAIN_WORKTREE" && task setup)
+```
+
+注意: symlink 復元を忘れると､worktree 削除後にリンク切れになる｡
+検証完了後は必ずメインリポジトリから `task setup` で復元すること｡

--- a/cmd/analyze-permissions/main.go
+++ b/cmd/analyze-permissions/main.go
@@ -282,9 +282,18 @@ func countUniqueFiles(results []ScanResult) int {
 	return len(seen)
 }
 
+// resolveProjectsDir は JSONL スキャン対象の projects ディレクトリを決定する｡
+func resolveProjectsDir(projectsDirFlag, home string) string {
+	if projectsDirFlag != "" {
+		return projectsDirFlag
+	}
+	return filepath.Join(home, ".claude", "projects")
+}
+
 func main() {
 	days := flag.Int("days", 30, "集計期間(日数)")
 	settingsPath := flag.String("settings", "", "settings.json パス (デフォルト: git ルートの settings.json または ~/.claude/settings.json)")
+	projectsDirFlag := flag.String("projects-dir", "", "projects ディレクトリパス (デフォルト: ~/.claude/projects)")
 	flag.Parse()
 
 	home, err := os.UserHomeDir()
@@ -307,8 +316,7 @@ func main() {
 		*settingsPath = resolved
 	}
 
-	// JSONL セッションログは常に ~/.claude/projects/ を走査
-	projectsDir := filepath.Join(home, ".claude", "projects")
+	projectsDir := resolveProjectsDir(*projectsDirFlag, home)
 
 	// パーミッション読み込み
 	allow, deny, ask, err := LoadPermissions(*settingsPath)

--- a/cmd/analyze-permissions/main_test.go
+++ b/cmd/analyze-permissions/main_test.go
@@ -133,6 +133,24 @@ func TestGenerateReport(t *testing.T) {
 	})
 }
 
+func TestResolveProjectsDir(t *testing.T) {
+	t.Run("--projects-dir 指定時はそのパスを使う", func(t *testing.T) {
+		got := resolveProjectsDir("/custom/projects", "/home/user")
+		want := "/custom/projects"
+		if got != want {
+			t.Errorf("resolveProjectsDir: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("未指定時は ~/.claude/projects を使う", func(t *testing.T) {
+		got := resolveProjectsDir("", "/home/user")
+		want := "/home/user/.claude/projects"
+		if got != want {
+			t.Errorf("resolveProjectsDir: got %q, want %q", got, want)
+		}
+	})
+}
+
 func TestMatchPattern(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/cmd/analyze-webfetch/main.go
+++ b/cmd/analyze-webfetch/main.go
@@ -239,21 +239,31 @@ func countUniqueFiles(results []ScanResult) int {
 	return len(seen)
 }
 
+// resolveProjectsDir は JSONL スキャン対象の projects ディレクトリを決定する｡
+func resolveProjectsDir(projectsDirFlag, home string) string {
+	if projectsDirFlag != "" {
+		return projectsDirFlag
+	}
+	return filepath.Join(home, ".claude", "projects")
+}
+
 func main() {
 	days := flag.Int("days", 30, "集計期間(日数)")
 	settingsPath := flag.String("settings", "", "settings.json パス (デフォルト: ~/.claude/settings.json)")
+	projectsDirFlag := flag.String("projects-dir", "", "projects ディレクトリパス (デフォルト: ~/.claude/projects)")
 	flag.Parse()
 
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ホームディレクトリの取得に失敗: %v\n", err)
+		os.Exit(1)
+	}
+
 	if *settingsPath == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "ホームディレクトリの取得に失敗: %v\n", err)
-			os.Exit(1)
-		}
 		*settingsPath = filepath.Join(home, ".claude", "settings.json")
 	}
 
-	projectsDir := filepath.Join(filepath.Dir(*settingsPath), "projects")
+	projectsDir := resolveProjectsDir(*projectsDirFlag, home)
 
 	// Load current allowlist.
 	allowlist, err := LoadAllowlist(*settingsPath)

--- a/cmd/analyze-webfetch/main_test.go
+++ b/cmd/analyze-webfetch/main_test.go
@@ -5,6 +5,24 @@ import (
 	"testing"
 )
 
+func TestResolveProjectsDir(t *testing.T) {
+	t.Run("--projects-dir 指定時はそのパスを使う", func(t *testing.T) {
+		got := resolveProjectsDir("/custom/projects", "/home/user")
+		want := "/custom/projects"
+		if got != want {
+			t.Errorf("resolveProjectsDir: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("未指定時は ~/.claude/projects を使う", func(t *testing.T) {
+		got := resolveProjectsDir("", "/home/user")
+		want := "/home/user/.claude/projects"
+		if got != want {
+			t.Errorf("resolveProjectsDir: got %q, want %q", got, want)
+		}
+	})
+}
+
 func TestGenerateReport(t *testing.T) {
 	t.Run("generates report with recommendations", func(t *testing.T) {
 		scanResults := []ScanResult{

--- a/skills/usadamasa-finalize-pr/SKILL.md
+++ b/skills/usadamasa-finalize-pr/SKILL.md
@@ -119,11 +119,11 @@ gh pr merge --merge
 worktree 環境かどうかを判定する:
 
 ```bash
-cat .git
+GIT_DIR=$(git rev-parse --git-dir)
+GIT_COMMON=$(git rev-parse --git-common-dir)
+# GIT_DIR != GIT_COMMON → worktree 環境
+# GIT_DIR == GIT_COMMON → 通常環境 (クリーンアップ不要、Step 7 へ)
 ```
-
-- **`.git` がファイル** (内容が `gitdir: ...`) → worktree 環境
-- **`.git` がディレクトリ** → 通常環境 (クリーンアップ不要、Step 7 へ)
 
 worktree 環境の場合:
 
@@ -132,9 +132,9 @@ worktree 環境の場合:
    WORKTREE_PATH=$(pwd)
    ```
 
-2. main worktree (bare repo) のパスを取得:
+2. main worktree (通常リポジトリ + git worktree の親) のパスを取得:
    ```bash
-   MAIN_WORKTREE=$(git worktree list --porcelain | head -1 | sed 's/worktree //')
+   MAIN_WORKTREE=$(git rev-parse --git-common-dir | xargs dirname)
    ```
 
 3. ユーザーに worktree 削除を案内する:

--- a/skills/usadamasa-session-handoff/SKILL.md
+++ b/skills/usadamasa-session-handoff/SKILL.md
@@ -84,28 +84,21 @@ PLAN.md が存在する場合は、その進捗状態も確認する。
 
 #### worktree 環境の検出と親 memory への保存
 
-まず `.git` がファイルかディレクトリかを確認し、worktree 環境かどうかを判定する:
+`git rev-parse` で worktree 環境かどうかを判定する:
 
 ```bash
-# .git がファイルなら worktree 環境
-cat .git
-# → "gitdir: /path/to/.git/worktrees/feature" なら worktree
-# → ディレクトリなら通常のリポジトリ
+GIT_DIR=$(git rev-parse --git-dir)
+GIT_COMMON=$(git rev-parse --git-common-dir)
+# GIT_DIR != GIT_COMMON → worktree 環境
+# GIT_DIR == GIT_COMMON → 通常のリポジトリ
 ```
 
 **worktree 環境の場合、2か所に保存する:**
 
 ```bash
-# .git ファイルから gitdir を取得
-GIT_DIR=$(sed 's/^gitdir: //' .git | tr -d '\n')
-
-# ブランチ名を取得 (親 memory のファイル名に使う)
-BRANCH_NAME=$(sed 's|ref: refs/heads/||' "$GIT_DIR/HEAD" | tr -d '\n')
-
-# commondir から親 .git ディレクトリを特定
-COMMON_REL=$(cat "$GIT_DIR/commondir" | tr -d '\n')
-# 相対パスを絶対パスに変換
-COMMON_ABS="$(cd "$GIT_DIR" && cd "$COMMON_REL" && pwd)"
+GIT_DIR=$(git rev-parse --git-dir)
+BRANCH_NAME=$(git branch --show-current)
+COMMON_ABS=$(git rev-parse --git-common-dir | xargs realpath)
 PARENT_ROOT="$(dirname "$COMMON_ABS")"
 
 # パスエンコード: / . _ を - に変換

--- a/tests/setup-symlinks.bats
+++ b/tests/setup-symlinks.bats
@@ -79,3 +79,66 @@ teardown() {
   # (CLAUDE-global.md は別途処理されるため)
   ! grep -E 'for file in.*CLAUDE\.md' "$REPO_ROOT/Taskfile.yml"
 }
+
+# =============================================================================
+# worktree 環境関連の構造テスト
+# =============================================================================
+
+@test "CLAUDE.md に git rev-parse による worktree 判定の記載がある" {
+  grep -q "git rev-parse --git-dir" "$REPO_ROOT/CLAUDE.md"
+  grep -q "git rev-parse --git-common-dir" "$REPO_ROOT/CLAUDE.md"
+}
+
+@test "CLAUDE.md に worktree 用パス解決 (pwd)/settings.json の記載がある" {
+  grep -q 'pwd)/settings.json' "$REPO_ROOT/CLAUDE.md"
+}
+
+@test "CLAUDE.md に CLI ツールの --settings オプション記載がある" {
+  grep -q '\-\-settings' "$REPO_ROOT/CLAUDE.md"
+}
+
+@test "permission-optimizer に worktree チェックの記載がある" {
+  grep -q "worktree" "$REPO_ROOT/.claude/skills/permission-optimizer/SKILL.md"
+  grep -q 'settings.*pwd' "$REPO_ROOT/.claude/skills/permission-optimizer/SKILL.md"
+}
+
+@test "webfetch-domain-manager に worktree チェックの記載がある" {
+  grep -q "worktree" "$REPO_ROOT/.claude/skills/webfetch-domain-manager/SKILL.md"
+  grep -q 'settings.*pwd' "$REPO_ROOT/.claude/skills/webfetch-domain-manager/SKILL.md"
+}
+
+@test "manage-claude-envs に worktree 用パス (pwd)/env.sh の記載がある" {
+  grep -q 'pwd)/env.sh' "$REPO_ROOT/.claude/skills/manage-claude-envs/skill.md"
+}
+
+# =============================================================================
+# worktree 検出方式の統一テスト (git rev-parse)
+# =============================================================================
+
+@test "CLAUDE-global.md に git rev-parse による worktree 判定の記載がある" {
+  grep -q "git rev-parse --git-dir" "$REPO_ROOT/CLAUDE-global.md"
+  grep -q "git rev-parse --git-common-dir" "$REPO_ROOT/CLAUDE-global.md"
+}
+
+@test "CLAUDE-global.md に cat .git による判定が残っていない" {
+  ! grep -q 'cat \.git' "$REPO_ROOT/CLAUDE-global.md"
+}
+
+@test "finalize-pr スキルに git rev-parse による worktree 判定の記載がある" {
+  grep -q "git rev-parse --git-dir" "$REPO_ROOT/skills/usadamasa-finalize-pr/SKILL.md"
+  grep -q "git rev-parse --git-common-dir" "$REPO_ROOT/skills/usadamasa-finalize-pr/SKILL.md"
+}
+
+@test "finalize-pr スキルに cat .git による判定が残っていない" {
+  ! grep -q 'cat \.git' "$REPO_ROOT/skills/usadamasa-finalize-pr/SKILL.md"
+}
+
+@test "session-handoff スキルに git rev-parse による worktree 判定の記載がある" {
+  grep -q "git rev-parse --git-dir" "$REPO_ROOT/skills/usadamasa-session-handoff/SKILL.md"
+  grep -q "git rev-parse --git-common-dir" "$REPO_ROOT/skills/usadamasa-session-handoff/SKILL.md"
+}
+
+@test "claude-config-management に worktree 環境チェックの記載がある" {
+  grep -q "worktree 環境チェック" "$REPO_ROOT/.claude/skills/claude-config-management/SKILL.md"
+  grep -q "git rev-parse --git-dir" "$REPO_ROOT/.claude/skills/claude-config-management/SKILL.md"
+}


### PR DESCRIPTION
## Summary

- Replace all `cat .git` worktree detection with `git rev-parse --git-dir` / `--git-common-dir` comparison across CLAUDE-global.md, finalize-pr, and session-handoff skills
- Add `--projects-dir` flag to `analyze-permissions` and `analyze-webfetch` CLI tools, decoupling JSONL scan path from `--settings` path to fix worktree environments
- Update skill docs (permission-optimizer, webfetch-domain-manager, claude-config-management, manage-claude-envs) with corrected worktree command examples and improved structure
- Fix "bare リポジトリ" → "通常リポジトリ + git worktree (linked worktree)" and `MAIN_WORKTREE` derivation in CLAUDE.md
- Add 6 bats regression tests to prevent `cat .git` from being reintroduced

## Test plan

- [x] `task test` — 96 bats tests + Go tests all pass
- [x] `go vet ./cmd/...` — clean
- [x] `grep -r "cat .git" CLAUDE-global.md skills/` — zero matches (no residual `cat .git`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)