### PR TITLE
refactor: CLAUDE-global.mdをベストプラクティスに基づき再構成

### DIFF
--- a/tests/setup-symlinks.bats
+++ b/tests/setup-symlinks.bats
@@ -71,9 +71,9 @@ teardown() {
   ln -sfn "$REPO_ROOT/dotclaude/CLAUDE-global.md" "$FAKE_HOME/.claude/CLAUDE.md"
 
   # グローバル設定特有の内容が含まれる
-  grep -q "Conversation Guidelines" "$FAKE_HOME/.claude/CLAUDE.md"
-  grep -q "Development Philosophy" "$FAKE_HOME/.claude/CLAUDE.md"
-  grep -q "Test-Driven Development" "$FAKE_HOME/.claude/CLAUDE.md"
+  grep -q "コア原則" "$FAKE_HOME/.claude/CLAUDE.md"
+  grep -q "ワークフロー" "$FAKE_HOME/.claude/CLAUDE.md"
+  grep -q "テスト駆動開発" "$FAKE_HOME/.claude/CLAUDE.md"
 }
 
 @test "CLAUDE.md (プロジェクトスコープ) にグローバル設定が含まれない" {


### PR DESCRIPTION
## Summary

- コア原則(シンプル第一・根本解決・影響最小化・検証前提)を冒頭に追加し、判断に迷ったときの指針を明確化
- 自律的バグ修正・自己改善ループの新セクションを追加
- セクション名を日本語に統一し、優先度順・ワークフロー順に再配置(7→6セクション)
- TDD(8→3行)、CI(3→2行)、subagent(モデル名ハードコード→原則ベース)等を圧縮・改善
- 全体を101行→93行に削減しつつ3つの新概念を追加

## Test plan

- [x] `task setup` で symlink が正しく更新されることを確認
- [x] `~/.claude/CLAUDE.md` が新しい内容を反映していることを確認
- [ ] 新規セッションで CLAUDE.md が正しく読み込まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)