### PR TITLE
feat: consolidate git permissions and add git config write guard

### DIFF
--- a/dotclaude/CLAUDE-global.md
+++ b/dotclaude/CLAUDE-global.md
@@ -61,8 +61,11 @@ git 操作 (commit, push, PR作成) の前に、必ず以下を実行する:
 
 ### 破壊的操作
 
-- `git rebase`, `git reset` は原則使用しない｡必要な場合はユーザー確認を取る｡
+- `git push --force` は原則使用しない｡`--force-with-lease` を使う｡
+- `git reset --hard` は変更消失のリスクがあるため慎重に使用する｡
 - `git stash` より worktree 分離を優先する｡
+- `git config` の書き込みは PreToolUse フック (`guard-git-config.sh`) でブロックされる｡
+  読み取り (`--get`, `--list`) と worktree 用 `remote.origin.fetch` 設定は例外として許可｡
 
 ## セッション管理
 

--- a/dotclaude/hooks/guard-git-config.sh
+++ b/dotclaude/hooks/guard-git-config.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -euo pipefail
+# git config 書き込みガードフック
+# 読み取り系と worktree 用 remote.origin.fetch 以外の git config 書き込みをブロックする
+
+INPUT=$(cat)
+readonly INPUT
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name')
+readonly TOOL_NAME
+
+# Bash 以外のツールは対象外
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
+
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command')
+readonly COMMAND
+
+# コマンドの先頭トークンを抽出(パイプやチェーン前の最初のコマンド)
+# "git config ..." の部分だけを判定対象にする
+FIRST_CMD="${COMMAND%%|*}"
+FIRST_CMD="${FIRST_CMD%%&&*}"
+FIRST_CMD="${FIRST_CMD%%;*}"
+
+# git config 以外のコマンドは通過
+# git -c ... はインライン設定であり書き込みではないため通過
+if ! printf '%s' "$FIRST_CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+config([[:space:]]|$)'; then
+  exit 0
+fi
+
+# 読み取り系オプション: 通過
+if printf '%s' "$FIRST_CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+config[[:space:]]+.*(--get|--get-all|--get-regexp|--get-urlmatch|--list|--show-origin|--show-scope|-l)([[:space:]]|$)'; then
+  exit 0
+fi
+
+# worktree 例外: remote.origin.fetch への設定は許可
+if printf '%s' "$FIRST_CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+config[[:space:]]+remote\.origin\.fetch([[:space:]]|$)'; then
+  exit 0
+fi
+
+# 引数なしの git config <key> (値の読み取り) を判定
+# git config <key> は読み取り、git config <key> <value> は書き込み
+# --global, --local, --system, --unset, --unset-all, --replace-all, --add 等がある場合は書き込み
+if printf '%s' "$FIRST_CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+config[[:space:]]+--(global|local|system|worktree|file|blob|unset|unset-all|replace-all|add|rename-section|remove-section|edit)([[:space:]]|$)'; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"git config の書き込みはフックによりブロックされました。読み取り (--get, --list) と remote.origin.fetch の設定のみ許可されています。"}}\n'
+  exit 0
+fi
+
+# フラグなしの git config <key> <value> を検出
+# git config <key> のみ(引数1つ)なら読み取り、<key> <value>(引数2つ以上)なら書き込み
+# "git config" の後のトークン数をカウント
+CONFIG_ARGS="${FIRST_CMD#*git config}"
+CONFIG_ARGS=$(printf '%s' "$CONFIG_ARGS" | sed 's/^[[:space:]]*//')
+
+# 空なら git config 単体(ヘルプ表示) → 通過
+if [ -z "$CONFIG_ARGS" ]; then
+  exit 0
+fi
+
+# トークンをカウント(シンプルなスペース区切り)
+# 1トークン = 読み取り(key のみ)、2トークン以上 = 書き込み(key + value)
+WORD_COUNT=0
+IN_QUOTE=false
+QUOTE_CHAR=""
+for (( i=0; i<${#CONFIG_ARGS}; i++ )); do
+  CHAR="${CONFIG_ARGS:$i:1}"
+  if $IN_QUOTE; then
+    if [ "$CHAR" = "$QUOTE_CHAR" ]; then
+      IN_QUOTE=false
+    fi
+  elif [ "$CHAR" = '"' ] || [ "$CHAR" = "'" ]; then
+    if [ "$WORD_COUNT" -eq 0 ] || [ "${CONFIG_ARGS:$((i-1)):1}" = " " ]; then
+      IN_QUOTE=true
+      QUOTE_CHAR="$CHAR"
+      WORD_COUNT=$((WORD_COUNT + 1))
+    fi
+  elif [ "$CHAR" = " " ] || [ "$CHAR" = "	" ]; then
+    continue
+  else
+    if [ "$i" -eq 0 ] || [ "${CONFIG_ARGS:$((i-1)):1}" = " " ] || [ "${CONFIG_ARGS:$((i-1)):1}" = "	" ]; then
+      WORD_COUNT=$((WORD_COUNT + 1))
+    fi
+  fi
+done
+
+if [ "$WORD_COUNT" -ge 2 ]; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"git config の書き込みはフックによりブロックされました。読み取り (--get, --list) と remote.origin.fetch の設定のみ許可されています。"}}\n'
+  exit 0
+fi
+
+# 1トークン以下 = 読み取り(git config <key>) → 通過
+exit 0

--- a/dotclaude/settings.json
+++ b/dotclaude/settings.json
@@ -16,29 +16,7 @@
       "Bash(docker tag:*)",
       "Bash(docker volume:*)",
       "Bash(gh:*)",
-      "Bash(git add:*)",
-      "Bash(git branch:*)",
-      "Bash(git checkout:*)",
-      "Bash(git commit:*)",
-      "Bash(git config --get:*)",
-      "Bash(git config remote.origin.fetch:*)",
-      "Bash(git diff:*)",
-      "Bash(git fetch:*)",
-      "Bash(git log:*)",
-      "Bash(git ls-files:*)",
-      "Bash(git ls-tree:*)",
-      "Bash(git merge-base:*)",
-      "Bash(git mv:*)",
-      "Bash(git pull:*)",
-      "Bash(git push:*)",
-      "Bash(git remote:*)",
-      "Bash(git rev-list:*)",
-      "Bash(git rev-parse:*)",
-      "Bash(git rm:*)",
-      "Bash(git show:*)",
-      "Bash(git status:*)",
-      "Bash(git tag:*)",
-      "Bash(git worktree:*)",
+      "Bash(git:*)",
       "Bash(go build:*)",
       "Bash(go clean:*)",
       "Bash(go doc:*)",
@@ -143,10 +121,6 @@
     "ask": [
       "Bash(diff:*)",
       "Bash(brew install:*)",
-      "Bash(git config:*)",
-      "Bash(git rebase:*)",
-      "Bash(git reset:*)",
-      "Bash(git stash:*)",
       "Bash(rm -rf:*)",
       "mcp__plugin_atlassian_atlassian__createConfluencePage"
     ]
@@ -170,6 +144,15 @@
           {
             "type": "command",
             "command": "$HOME/.claude/hooks/guard-home-dir.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/guard-git-config.sh"
           }
         ]
       }

--- a/dotclaude/skills/commit-push-pr/SKILL.md
+++ b/dotclaude/skills/commit-push-pr/SKILL.md
@@ -102,7 +102,7 @@ SQUASH_BASE=$(git merge-base HEAD "origin/$PARENT")
 
 2. 非対話的 rebase で fixup:
    ```bash
-   GIT_SEQUENCE_EDITOR="sed -i '' '2,\$s/^pick/fixup/'" git rebase -i "$SQUASH_BASE"
+   git -c sequence.editor="sed -i '' '2,\$s/^pick/fixup/'" rebase -i "$SQUASH_BASE"
    ```
    - コンフリクト時: `git rebase --abort` で中止し、ユーザーに手動解決を促す
 

--- a/tests/guard-git-config.bats
+++ b/tests/guard-git-config.bats
@@ -1,0 +1,226 @@
+#!/usr/bin/env bats
+# guard-git-config.sh のテスト
+bats_require_minimum_version 1.5.0
+
+SCRIPT_PATH="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/dotclaude/hooks/guard-git-config.sh"
+
+setup() {
+  TEST_TMPDIR=$(mktemp -d)
+  export TEST_TMPDIR
+}
+
+teardown() {
+  [ -n "$TEST_TMPDIR" ] && rm -rf "$TEST_TMPDIR"
+}
+
+# ヘルパー: PreToolUse の JSON 入力を生成 (jq で安全にエスケープ)
+make_input() {
+  local command="$1"
+  jq -n --arg cmd "$command" '{"tool_name":"Bash","tool_input":{"command":$cmd}}'
+}
+
+# =============================================================================
+# git config 以外のコマンド → 通過
+# =============================================================================
+
+@test "git status: 通過" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git status")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "git commit -m 'test': 通過" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git commit -m 'test'")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "git push origin main: 通過" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git push origin main")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "git diff HEAD: 通過" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git diff HEAD")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "Bash 以外のツール: 通過" {
+  run bash "$SCRIPT_PATH" <<< '{"tool_name":"Read","tool_input":{"file_path":"/tmp/test"}}'
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "git 以外の Bash コマンド: 通過" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "ls -la")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# =============================================================================
+# 読み取り系 git config → 通過
+# =============================================================================
+
+@test "git config --get user.name: 通過" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config --get user.name")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "git config --get-all remote.origin.url: 通過" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config --get-all remote.origin.url")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "git config --get-regexp 'remote.*': 通過" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config --get-regexp 'remote.*'")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "git config --get-urlmatch http https://example.com: 通過" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config --get-urlmatch http https://example.com")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "git config --list: 通過" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config --list")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "git config -l: 通過" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config -l")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "git config --show-origin user.name: 通過" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config --show-origin user.name")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "git config --show-scope user.name: 通過" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config --show-scope user.name")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# =============================================================================
+# worktree 例外: remote.origin.fetch → 通過
+# =============================================================================
+
+@test "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*': 通過 (worktree 例外)" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config remote.origin.fetch \"+refs/heads/*:refs/remotes/origin/*\"")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "git config remote.origin.fetch: 通過 (読み取り)" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config remote.origin.fetch")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# =============================================================================
+# 書き込み系 git config → ブロック
+# =============================================================================
+
+@test "git config user.name 'foo': ブロック" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config user.name \"foo\"")"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision":"deny"'* ]]
+}
+
+@test "git config --global core.editor vim: ブロック" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config --global core.editor vim")"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision":"deny"'* ]]
+}
+
+@test "git config --unset foo: ブロック" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config --unset foo")"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision":"deny"'* ]]
+}
+
+@test "git config --unset-all foo: ブロック" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config --unset-all foo")"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision":"deny"'* ]]
+}
+
+@test "git config --replace-all foo bar: ブロック" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config --replace-all foo bar")"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision":"deny"'* ]]
+}
+
+@test "git config --add foo bar: ブロック" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config --add foo bar")"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision":"deny"'* ]]
+}
+
+@test "git config --local user.email 'test@test.com': ブロック" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config --local user.email \"test@test.com\"")"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision":"deny"'* ]]
+}
+
+# =============================================================================
+# git -c (インラインconfig) → 通過
+# =============================================================================
+
+@test "git -c sequence.editor='...' rebase: 通過 (インライン config)" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git -c sequence.editor=\"sed -i '' '2,\\\$s/^pick/fixup/'\" rebase -i abc123")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# =============================================================================
+# パイプ・チェーンを含むコマンド
+# =============================================================================
+
+@test "git config --get ... が含まれるパイプコマンド: 通過" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config --get remote.origin.fetch | grep refs")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "git config user.name ... && echo done: ブロック" {
+  run bash "$SCRIPT_PATH" <<< "$(make_input "git config user.name \"foo\" && echo done")"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision":"deny"'* ]]
+}


### PR DESCRIPTION
## Summary
- 24個の個別 `Bash(git ...:*)` パーミッションを `Bash(git:*)` 1個に集約し、git merge / cherry-pick 等でのプロンプト発生を解消
- `git config` 書き込みのみを PreToolUse フック (`guard-git-config.sh`) でブロックする多層防御を導入
- `ask` セクションから git 関連4エントリ (config/rebase/reset/stash) を削除
- commit-push-pr スキルの `GIT_SEQUENCE_EDITOR` を `git -c sequence.editor` に変更し `Bash(git:*)` マッチを確保

## Changes
- `dotclaude/settings.json`: パーミッション集約 + フック登録
- `dotclaude/hooks/guard-git-config.sh`: 新規 - git config 書き込みガードフック
- `tests/guard-git-config.bats`: 新規 - フックテスト 26ケース
- `dotclaude/skills/commit-push-pr/SKILL.md`: rebase コマンド修正
- `dotclaude/CLAUDE-global.md`: 破壊的操作セクション更新

## Test plan
- [x] `task test` で全149 bats テスト + Go テスト通過
- [x] Docker 検証 (kaizen-claude-config) で 20/20 パターン PASS
- [ ] 新セッションで git status/commit/push がプロンプトなしで動くこと
- [ ] 新セッションで git config user.name "test" がフックでブロックされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)