### PR TITLE
feat: add main repo auto-sync to worktree hooks

### DIFF
--- a/dotclaude/hooks/lib/sync-main-repo.sh
+++ b/dotclaude/hooks/lib/sync-main-repo.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# sync-main-repo.sh
+# メインリポジトリを最新に同期するための共有ライブラリ
+#
+# 提供関数:
+#   resolve_main_repo <worktree-path>  worktree パスから親リポジトリルートを stdout に出力
+#   sync_main_repo <main-repo-path>    fetch + ff-only merge でメインリポジトリを同期
+#
+# 依存: hook-logger.sh (is_dry_run, log_info, log_error, log_skip, logged_cmd)
+
+# worktree パスから親リポジトリのルートディレクトリを解決する
+# .git ファイル → gitdir → commondir → 親リポジトリルート
+# 通常リポジトリ (.git がディレクトリ) の場合は return 1
+# bare リポジトリにも対応: commondir のベース名が .git でなければ bare とみなす
+resolve_main_repo() {
+  local worktree_path="$1"
+  local git_file="$worktree_path/.git"
+
+  # .git がファイルでなければ worktree ではない
+  if [ ! -f "$git_file" ]; then
+    return 1
+  fi
+
+  # gitdir パスを取得
+  local git_dir
+  git_dir=$(sed 's/^gitdir: //' "$git_file" | tr -d '\n')
+  if [ ! -d "$git_dir" ]; then
+    return 1
+  fi
+
+  # commondir ファイルから親 .git ディレクトリを特定
+  local common_dir_file="$git_dir/commondir"
+  if [ ! -f "$common_dir_file" ]; then
+    return 1
+  fi
+
+  local common_rel
+  common_rel=$(tr -d '\n' < "$common_dir_file")
+
+  # 相対パスを絶対パスに変換
+  local common_abs
+  if [[ "$common_rel" == /* ]]; then
+    common_abs="$common_rel"
+  else
+    common_abs="$(cd "$git_dir" && cd "$common_rel" && pwd)"
+  fi
+
+  # bare リポジトリ判定: commondir のベース名が .git なら通常リポジトリ
+  local base
+  base=$(basename "$common_abs")
+  if [ "$base" = ".git" ]; then
+    # 通常リポジトリ: .git ディレクトリの親がリポジトリルート
+    dirname "$common_abs"
+  else
+    # bare リポジトリ: commondir 自体がリポジトリルート
+    echo "$common_abs"
+  fi
+  return 0
+}
+
+# メインリポジトリを fetch + ff-only merge で同期する
+# 実際の失敗 (fetch, merge, config) は return 1 で呼び出し元に伝播する
+# skip 条件 (detached HEAD, feature ブランチ中, デフォルトブランチ不在) は return 0
+sync_main_repo() {
+  local main_repo="$1"
+
+  if [ ! -d "$main_repo" ]; then
+    log_error "sync: invalid path: $main_repo"
+    return 1
+  fi
+
+  # remote.origin.fetch が空なら設定 (worktree 環境の既知問題)
+  local fetch_config
+  fetch_config=$(git -C "$main_repo" config --get remote.origin.fetch 2>/dev/null || true)
+  if [ -z "$fetch_config" ]; then
+    log_info "sync: setting remote.origin.fetch"
+    if is_dry_run; then
+      log_info "sync: CMD    git -C $main_repo config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*"
+    else
+      if ! git -C "$main_repo" config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" 2>/dev/null; then
+        log_error "sync: failed to set remote.origin.fetch"
+        return 1
+      fi
+    fi
+  fi
+
+  # git fetch origin
+  log_info "sync: fetching origin"
+  if is_dry_run; then
+    log_info "sync: CMD    git -C $main_repo fetch origin"
+  else
+    if ! git -C "$main_repo" fetch origin 2>/dev/null; then
+      log_error "sync: fetch failed"
+      return 1
+    fi
+  fi
+
+  # デフォルトブランチを検出 (main → master の順)
+  local default_branch=""
+  if is_dry_run; then
+    default_branch="main"
+    log_info "sync: CMD    git -C $main_repo show-ref --verify refs/heads/main"
+  else
+    if git -C "$main_repo" show-ref --verify --quiet "refs/heads/main" 2>/dev/null; then
+      default_branch="main"
+    elif git -C "$main_repo" show-ref --verify --quiet "refs/heads/master" 2>/dev/null; then
+      default_branch="master"
+    else
+      log_skip "sync: no default branch found (main/master)"
+      return 0
+    fi
+  fi
+
+  # bare リポジトリ判定
+  local is_bare="false"
+  if ! is_dry_run; then
+    is_bare=$(git -C "$main_repo" rev-parse --is-bare-repository 2>/dev/null) || {
+      log_info "sync: could not determine bare status, assuming non-bare"
+      is_bare="false"
+    }
+  fi
+
+  if [ "$is_bare" = "true" ]; then
+    # bare リポジトリ: merge できないので update-ref でブランチを進める
+    # ローカルブランチが origin の先祖であることを確認 (ff-only 相当)
+    log_info "sync: updating ref refs/heads/$default_branch (bare repo)"
+    if is_dry_run; then
+      log_info "sync: CMD    git -C $main_repo update-ref refs/heads/$default_branch refs/remotes/origin/$default_branch"
+    else
+      local local_ref remote_ref
+      local_ref=$(git -C "$main_repo" rev-parse "refs/heads/$default_branch" 2>/dev/null) || {
+        log_info "sync: local ref $default_branch not found (new branch?)"
+        local_ref=""
+      }
+      remote_ref=$(git -C "$main_repo" rev-parse "refs/remotes/origin/$default_branch" 2>/dev/null) || {
+        log_info "sync: remote ref origin/$default_branch not found"
+        remote_ref=""
+      }
+      if [ -z "$remote_ref" ]; then
+        log_skip "sync: remote ref origin/$default_branch not found"
+        return 0
+      fi
+      if [ "$local_ref" = "$remote_ref" ]; then
+        log_info "sync: already up to date"
+        return 0
+      fi
+      # ff-only チェック: local が remote の先祖かどうか
+      if [ -n "$local_ref" ] && ! git -C "$main_repo" merge-base --is-ancestor "$local_ref" "$remote_ref" 2>/dev/null; then
+        log_error "sync: update-ref failed (diverged?)"
+        return 1
+      fi
+      if ! git -C "$main_repo" update-ref "refs/heads/$default_branch" "$remote_ref" 2>/dev/null; then
+        log_error "sync: update-ref failed"
+        return 1
+      fi
+    fi
+  else
+    # 通常リポジトリ: merge --ff-only で進める
+    # 現在のブランチを確認
+    local current_branch
+    if is_dry_run; then
+      current_branch="$default_branch"
+      log_info "sync: CMD    git -C $main_repo symbolic-ref --short HEAD"
+    else
+      current_branch=$(git -C "$main_repo" symbolic-ref --short HEAD 2>/dev/null || true)
+      if [ -z "$current_branch" ]; then
+        log_skip "sync: detached HEAD"
+        return 0
+      fi
+    fi
+
+    # デフォルトブランチをチェックアウト中でなければスキップ
+    if [ "$current_branch" != "$default_branch" ]; then
+      log_skip "sync: not on default branch (on $current_branch)"
+      return 0
+    fi
+
+    # ff-only merge
+    log_info "sync: merging origin/$default_branch"
+    if is_dry_run; then
+      log_info "sync: CMD    git -C $main_repo merge --ff-only origin/$default_branch"
+    else
+      if ! git -C "$main_repo" merge --ff-only "origin/$default_branch" 2>/dev/null; then
+        log_error "sync: merge --ff-only failed (diverged?)"
+        return 1
+      fi
+    fi
+  fi
+
+  log_info "sync: main repo synced successfully"
+  return 0
+}

--- a/dotclaude/hooks/worktree-remove.sh
+++ b/dotclaude/hooks/worktree-remove.sh
@@ -14,6 +14,8 @@ HOOK_NAME="worktree-remove"
 SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 # shellcheck disable=SC1091 # Dynamically resolved path
 source "$SCRIPT_DIR/lib/hook-logger.sh"
+# shellcheck disable=SC1091 # Dynamically resolved path
+source "$SCRIPT_DIR/lib/sync-main-repo.sh"
 
 # 前提コマンドチェック
 if ! command -v jq &>/dev/null; then
@@ -30,6 +32,9 @@ if [ -z "$WORKTREE_PATH" ]; then
   exit 1
 fi
 
+# 削除前にメインリポジトリパスを解決 (.git ファイルが消える前に)
+MAIN_REPO=$(resolve_main_repo "$WORKTREE_PATH" 2>/dev/null) || MAIN_REPO=""
+
 # メモリセーブ (失敗しても続行、DRY_RUN は環境変数として自動伝播)
 "$SCRIPT_DIR/worktree-memory-save.sh" "$WORKTREE_PATH" || true
 
@@ -43,4 +48,9 @@ else
     logged_cmd git worktree remove --force "$WORKTREE_PATH"
     logged_cmd git worktree prune
   fi
+fi
+
+# 削除後にメインリポジトリを同期
+if [ -n "$MAIN_REPO" ]; then
+  sync_main_repo "$MAIN_REPO"
 fi

--- a/tests/sync-main-repo.bats
+++ b/tests/sync-main-repo.bats
@@ -1,0 +1,510 @@
+#!/usr/bin/env bats
+# sync-main-repo.sh のテスト
+bats_require_minimum_version 1.5.0
+
+HOOKS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/dotclaude/hooks"
+
+setup() {
+  TEST_TMPDIR=$(mktemp -d)
+  MOCK_BIN="$TEST_TMPDIR/bin"
+  mkdir -p "$MOCK_BIN"
+
+  # hook-logger.sh を MOCK_BIN/lib にコピー
+  mkdir -p "$MOCK_BIN/lib"
+  cp "$HOOKS_DIR/lib/hook-logger.sh" "$MOCK_BIN/lib/hook-logger.sh"
+  cp "$HOOKS_DIR/lib/sync-main-repo.sh" "$MOCK_BIN/lib/sync-main-repo.sh"
+
+  # テスト用 worktree 構造を作成
+  TEST_PARENT_REPO="$TEST_TMPDIR/parent-repo"
+  TEST_WORKTREE="$TEST_TMPDIR/my-worktree"
+  mkdir -p "$TEST_PARENT_REPO/.git/worktrees/feature"
+  mkdir -p "$TEST_WORKTREE"
+
+  # commondir: worktree gitdir から親 .git への相対パス
+  echo "../.." > "$TEST_PARENT_REPO/.git/worktrees/feature/commondir"
+  # HEAD: ブランチ名の特定に使用
+  echo "ref: refs/heads/feature" > "$TEST_PARENT_REPO/.git/worktrees/feature/HEAD"
+  # ワークツリーの .git ファイル (worktree 判定のキー)
+  echo "gitdir: $TEST_PARENT_REPO/.git/worktrees/feature" > "$TEST_WORKTREE/.git"
+
+  export TEST_TMPDIR MOCK_BIN TEST_PARENT_REPO TEST_WORKTREE
+  export SCRIPT_DIR="$MOCK_BIN"
+  export HOOK_NAME="test"
+  export DRY_RUN=0
+}
+
+teardown() {
+  [ -n "$TEST_TMPDIR" ] && rm -rf "$TEST_TMPDIR"
+  unset SCRIPT_DIR HOOK_NAME DRY_RUN
+}
+
+# ヘルパー: sync-main-repo.sh をソースして関数を呼ぶラッパー
+_run_resolve() {
+  # shellcheck disable=SC1091
+  source "$MOCK_BIN/lib/hook-logger.sh"
+  # shellcheck disable=SC1091
+  source "$MOCK_BIN/lib/sync-main-repo.sh"
+  resolve_main_repo "$@"
+}
+
+_run_sync() {
+  export PATH="$MOCK_BIN:$PATH"
+  # shellcheck disable=SC1091
+  source "$MOCK_BIN/lib/hook-logger.sh"
+  # shellcheck disable=SC1091
+  source "$MOCK_BIN/lib/sync-main-repo.sh"
+  sync_main_repo "$@"
+}
+
+# =============================================================================
+# resolve_main_repo
+# =============================================================================
+
+@test "resolve_main_repo: 正常系 - 親リポジトリルートを返す" {
+  run _run_resolve "$TEST_WORKTREE"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == "$TEST_PARENT_REPO" ]]
+}
+
+@test "resolve_main_repo: 通常リポジトリ (.git がディレクトリ) は return 1" {
+  local normal_repo="$TEST_TMPDIR/normal-repo"
+  mkdir -p "$normal_repo/.git"
+
+  run _run_resolve "$normal_repo"
+
+  [ "$status" -eq 1 ]
+}
+
+@test "resolve_main_repo: .git ファイル未存在は return 1" {
+  local no_git="$TEST_TMPDIR/no-git"
+  mkdir -p "$no_git"
+
+  run _run_resolve "$no_git"
+
+  [ "$status" -eq 1 ]
+}
+
+@test "resolve_main_repo: commondir 未存在は return 1" {
+  rm "$TEST_PARENT_REPO/.git/worktrees/feature/commondir"
+
+  run _run_resolve "$TEST_WORKTREE"
+
+  [ "$status" -eq 1 ]
+}
+
+@test "resolve_main_repo: gitdir が存在しないディレクトリを指す場合は return 1" {
+  echo "gitdir: /nonexistent/path" > "$TEST_WORKTREE/.git"
+
+  run _run_resolve "$TEST_WORKTREE"
+
+  [ "$status" -eq 1 ]
+}
+
+# =============================================================================
+# sync_main_repo: 正常系
+# =============================================================================
+
+@test "sync_main_repo: fetch + merge 正常系" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "-C" ]; then shift 2; fi
+case "$1" in
+  config)
+    if [ "$2" = "--get" ]; then
+      echo "+refs/heads/*:refs/remotes/origin/*"
+      exit 0
+    fi
+    ;;
+  fetch) exit 0 ;;
+  show-ref)
+    if [[ "$*" == *"refs/heads/main"* ]]; then exit 0; fi
+    exit 1
+    ;;
+  symbolic-ref) echo "main"; exit 0 ;;
+  merge) exit 0 ;;
+esac
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_sync "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 0 ]
+  # fetch が呼ばれた
+  grep -q "fetch origin" "$TEST_TMPDIR/git-calls.log"
+  # merge が呼ばれた
+  grep -q "merge --ff-only origin/main" "$TEST_TMPDIR/git-calls.log"
+}
+
+@test "sync_main_repo: fetch 失敗時は return 1" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "-C" ]; then shift 2; fi
+case "$1" in
+  config)
+    if [ "$2" = "--get" ]; then
+      echo "+refs/heads/*:refs/remotes/origin/*"
+      exit 0
+    fi
+    ;;
+  fetch) exit 1 ;;
+esac
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_sync "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 1 ]
+  # merge は呼ばれない
+  run ! grep -q "merge" "$TEST_TMPDIR/git-calls.log"
+}
+
+@test "sync_main_repo: merge 失敗 (diverged) は return 1" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "-C" ]; then shift 2; fi
+case "$1" in
+  config)
+    if [ "$2" = "--get" ]; then
+      echo "+refs/heads/*:refs/remotes/origin/*"
+      exit 0
+    fi
+    ;;
+  fetch) exit 0 ;;
+  show-ref)
+    if [[ "$*" == *"refs/heads/main"* ]]; then exit 0; fi
+    exit 1
+    ;;
+  symbolic-ref) echo "main"; exit 0 ;;
+  merge) exit 1 ;;
+esac
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_sync "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"merge --ff-only failed"* ]]
+}
+
+@test "sync_main_repo: デフォルトブランチ不在 (main/master どちらもない) は return 0" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "-C" ]; then shift 2; fi
+case "$1" in
+  config)
+    if [ "$2" = "--get" ]; then
+      echo "+refs/heads/*:refs/remotes/origin/*"
+      exit 0
+    fi
+    ;;
+  fetch) exit 0 ;;
+  show-ref) exit 1 ;;
+esac
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_sync "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no default branch found"* ]]
+}
+
+@test "sync_main_repo: feature ブランチ中は merge スキップ" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "-C" ]; then shift 2; fi
+case "$1" in
+  config)
+    if [ "$2" = "--get" ]; then
+      echo "+refs/heads/*:refs/remotes/origin/*"
+      exit 0
+    fi
+    ;;
+  fetch) exit 0 ;;
+  show-ref)
+    if [[ "$*" == *"refs/heads/main"* ]]; then exit 0; fi
+    exit 1
+    ;;
+  symbolic-ref) echo "feature-branch"; exit 0 ;;
+  merge) echo "MERGE_SHOULD_NOT_BE_CALLED"; exit 1 ;;
+esac
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_sync "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not on default branch"* ]]
+  run ! grep -q "merge" "$TEST_TMPDIR/git-calls.log"
+}
+
+@test "sync_main_repo: detached HEAD は merge スキップ" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "-C" ]; then shift 2; fi
+case "$1" in
+  config)
+    if [ "$2" = "--get" ]; then
+      echo "+refs/heads/*:refs/remotes/origin/*"
+      exit 0
+    fi
+    ;;
+  fetch) exit 0 ;;
+  show-ref)
+    if [[ "$*" == *"refs/heads/main"* ]]; then exit 0; fi
+    exit 1
+    ;;
+  symbolic-ref) exit 1 ;;
+esac
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_sync "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"detached HEAD"* ]]
+}
+
+@test "sync_main_repo: master ブランチ検出" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "-C" ]; then shift 2; fi
+case "$1" in
+  config)
+    if [ "$2" = "--get" ]; then
+      echo "+refs/heads/*:refs/remotes/origin/*"
+      exit 0
+    fi
+    ;;
+  fetch) exit 0 ;;
+  show-ref)
+    if [[ "$*" == *"refs/heads/main"* ]]; then exit 1; fi
+    if [[ "$*" == *"refs/heads/master"* ]]; then exit 0; fi
+    exit 1
+    ;;
+  symbolic-ref) echo "master"; exit 0 ;;
+  merge) exit 0 ;;
+esac
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_sync "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 0 ]
+  grep -q "merge --ff-only origin/master" "$TEST_TMPDIR/git-calls.log"
+}
+
+@test "sync_main_repo: DRY_RUN モード" {
+  export DRY_RUN=1
+
+  run _run_sync "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[DRY-RUN]"* ]]
+  [[ "$output" == *"sync: CMD"* ]]
+  # 実際の git コマンドは呼ばれない (MOCK_BIN/git がないので)
+}
+
+@test "sync_main_repo: 無効パスは return 1" {
+  run _run_sync "/nonexistent/path"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"invalid path"* ]]
+}
+
+@test "sync_main_repo: remote.origin.fetch 未設定時に自動設定" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "-C" ]; then shift 2; fi
+case "$1" in
+  config)
+    if [ "$2" = "--get" ]; then
+      # 空を返す (未設定)
+      exit 1
+    fi
+    # config set は成功
+    exit 0
+    ;;
+  fetch) exit 0 ;;
+  show-ref)
+    if [[ "$*" == *"refs/heads/main"* ]]; then exit 0; fi
+    exit 1
+    ;;
+  symbolic-ref) echo "main"; exit 0 ;;
+  merge) exit 0 ;;
+esac
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_sync "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 0 ]
+  # config remote.origin.fetch が設定された
+  grep -q 'config remote.origin.fetch' "$TEST_TMPDIR/git-calls.log"
+}
+
+# =============================================================================
+# resolve_main_repo: bare リポジトリ
+# =============================================================================
+
+@test "resolve_main_repo: bare リポジトリの worktree からルートを解決" {
+  # bare リポジトリ構造 (ルートが .git で終わらない)
+  BARE_REPO="$TEST_TMPDIR/bare-repo.git"
+  BARE_WORKTREE="$TEST_TMPDIR/bare-wt"
+  mkdir -p "$BARE_REPO/worktrees/feature"
+  mkdir -p "$BARE_WORKTREE"
+
+  echo "../.." > "$BARE_REPO/worktrees/feature/commondir"
+  echo "ref: refs/heads/feature" > "$BARE_REPO/worktrees/feature/HEAD"
+  echo "gitdir: $BARE_REPO/worktrees/feature" > "$BARE_WORKTREE/.git"
+
+  run _run_resolve "$BARE_WORKTREE"
+
+  [ "$status" -eq 0 ]
+  # bare リポジトリでは commondir 自体がリポジトリルート
+  [[ "$output" == "$BARE_REPO" ]]
+}
+
+# =============================================================================
+# sync_main_repo: bare リポジトリ
+# =============================================================================
+
+@test "sync_main_repo: bare リポジトリで update-ref が使われる" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "-C" ]; then shift 2; fi
+case "$1" in
+  config)
+    if [ "$2" = "--get" ]; then
+      echo "+refs/heads/*:refs/remotes/origin/*"
+      exit 0
+    fi
+    ;;
+  fetch) exit 0 ;;
+  show-ref)
+    if [[ "$*" == *"refs/heads/main"* ]]; then exit 0; fi
+    exit 1
+    ;;
+  rev-parse)
+    if [ "$2" = "--is-bare-repository" ]; then
+      echo "true"
+      exit 0
+    fi
+    # rev-parse refs/heads/main
+    if [[ "$*" == *"refs/heads/main"* ]]; then
+      echo "abc123"
+      exit 0
+    fi
+    # rev-parse refs/remotes/origin/main
+    if [[ "$*" == *"refs/remotes/origin/main"* ]]; then
+      echo "def456"
+      exit 0
+    fi
+    ;;
+  merge-base) exit 0 ;;
+  update-ref) exit 0 ;;
+esac
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_sync "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 0 ]
+  # update-ref が呼ばれた (merge --ff-only ではなく)
+  grep -q "update-ref refs/heads/main def456" "$TEST_TMPDIR/git-calls.log"
+  run ! grep -q "merge --ff-only" "$TEST_TMPDIR/git-calls.log"
+}
+
+@test "sync_main_repo: bare リポジトリで diverged は return 1" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "-C" ]; then shift 2; fi
+case "$1" in
+  config)
+    if [ "$2" = "--get" ]; then
+      echo "+refs/heads/*:refs/remotes/origin/*"
+      exit 0
+    fi
+    ;;
+  fetch) exit 0 ;;
+  show-ref)
+    if [[ "$*" == *"refs/heads/main"* ]]; then exit 0; fi
+    exit 1
+    ;;
+  rev-parse)
+    if [ "$2" = "--is-bare-repository" ]; then
+      echo "true"
+      exit 0
+    fi
+    if [[ "$*" == *"refs/heads/main"* ]]; then echo "abc123"; exit 0; fi
+    if [[ "$*" == *"refs/remotes/origin/main"* ]]; then echo "def456"; exit 0; fi
+    ;;
+  merge-base) exit 1 ;;
+esac
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_sync "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"update-ref failed (diverged?)"* ]]
+}
+
+@test "sync_main_repo: bare リポジトリで already up to date" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "-C" ]; then shift 2; fi
+case "$1" in
+  config)
+    if [ "$2" = "--get" ]; then
+      echo "+refs/heads/*:refs/remotes/origin/*"
+      exit 0
+    fi
+    ;;
+  fetch) exit 0 ;;
+  show-ref)
+    if [[ "$*" == *"refs/heads/main"* ]]; then exit 0; fi
+    exit 1
+    ;;
+  rev-parse)
+    if [ "$2" = "--is-bare-repository" ]; then
+      echo "true"
+      exit 0
+    fi
+    # local と remote が同じ SHA
+    echo "abc123"
+    exit 0
+    ;;
+esac
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_sync "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already up to date"* ]]
+  run ! grep -q "update-ref" "$TEST_TMPDIR/git-calls.log"
+}

--- a/tests/worktree-remove.bats
+++ b/tests/worktree-remove.bats
@@ -13,12 +13,22 @@ setup() {
   REAL_HOOKS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/dotclaude/hooks"
   mkdir -p "$MOCK_BIN/lib"
   cp "$REAL_HOOKS_DIR/lib/hook-logger.sh" "$MOCK_BIN/lib/hook-logger.sh"
+  cp "$REAL_HOOKS_DIR/lib/sync-main-repo.sh" "$MOCK_BIN/lib/sync-main-repo.sh"
 
   # テスト用 worktree パス
   MOCK_WORKTREE_PATH="$TEST_TMPDIR/worktrees/test-repo/my-branch"
   mkdir -p "$MOCK_WORKTREE_PATH"
 
-  # git のモック (デフォルト: worktree remove 成功)
+  # resolve_main_repo 用の .git ファイル構造
+  TEST_PARENT_REPO="$TEST_TMPDIR/parent-repo"
+  mkdir -p "$TEST_PARENT_REPO/.git/worktrees/my-branch"
+  echo "../.." > "$TEST_PARENT_REPO/.git/worktrees/my-branch/commondir"
+  echo "ref: refs/heads/my-branch" > "$TEST_PARENT_REPO/.git/worktrees/my-branch/HEAD"
+  echo "gitdir: $TEST_PARENT_REPO/.git/worktrees/my-branch" > "$MOCK_WORKTREE_PATH/.git"
+
+  export TEST_PARENT_REPO
+
+  # git のモック (デフォルト: worktree remove 成功、sync 関連も処理)
   cat > "$MOCK_BIN/git" << 'MOCKEOF'
 #!/bin/bash
 echo "$@" >> "$TEST_TMPDIR/git-calls.log"
@@ -30,7 +40,27 @@ if [ "$1" = "worktree" ]; then
     exit 0
   fi
 fi
-/usr/bin/git "$@"
+# -C 付きの sync 系コマンド
+if [ "$1" = "-C" ]; then
+  shift 2
+  case "$1" in
+    config)
+      if [ "$2" = "--get" ]; then
+        echo "+refs/heads/*:refs/remotes/origin/*"
+        exit 0
+      fi
+      ;;
+    fetch) exit 0 ;;
+    show-ref)
+      if [[ "$*" == *"refs/heads/main"* ]]; then exit 0; fi
+      exit 1
+      ;;
+    symbolic-ref) echo "main"; exit 0 ;;
+    merge) exit 0 ;;
+  esac
+  exit 0
+fi
+exit 0
 MOCKEOF
   chmod +x "$MOCK_BIN/git"
 
@@ -99,7 +129,7 @@ MOCKEOF
 }
 
 @test "worktree remove 失敗時は --force でリトライされる" {
-  # 最初の remove は失敗、--force 付きで成功
+  # 最初の remove は失敗、--force 付きで成功 + sync 系コマンドも処理
   cat > "$MOCK_BIN/git" << 'MOCKEOF'
 #!/bin/bash
 echo "$@" >> "$TEST_TMPDIR/git-calls.log"
@@ -115,7 +145,26 @@ if [ "$1" = "worktree" ]; then
     exit 0
   fi
 fi
-/usr/bin/git "$@"
+if [ "$1" = "-C" ]; then
+  shift 2
+  case "$1" in
+    config)
+      if [ "$2" = "--get" ]; then
+        echo "+refs/heads/*:refs/remotes/origin/*"
+        exit 0
+      fi
+      ;;
+    fetch) exit 0 ;;
+    show-ref)
+      if [[ "$*" == *"refs/heads/main"* ]]; then exit 0; fi
+      exit 1
+      ;;
+    symbolic-ref) echo "main"; exit 0 ;;
+    merge) exit 0 ;;
+  esac
+  exit 0
+fi
+exit 0
 MOCKEOF
   chmod +x "$MOCK_BIN/git"
 
@@ -189,4 +238,64 @@ MOCKEOF
   [ "$status" -eq 0 ]
   [ -f "$TEST_TMPDIR/save-env.log" ]
   [[ "$(cat "$TEST_TMPDIR/save-env.log")" == *"SAVE_DRY_RUN=1"* ]]
+}
+
+# =============================================================================
+# sync 連携
+# =============================================================================
+
+@test "sync が worktree 削除後に実行される" {
+  run bash "$SCRIPT_PATH" <<< "{\"worktree_path\":\"$MOCK_WORKTREE_PATH\"}"
+
+  [ "$status" -eq 0 ]
+  # fetch が呼ばれた (sync が実行された)
+  grep -q "fetch origin" "$TEST_TMPDIR/git-calls.log"
+  # worktree remove が fetch より先に呼ばれたことを確認
+  local remove_line fetch_line
+  remove_line=$(grep -n "worktree remove" "$TEST_TMPDIR/git-calls.log" | head -1 | cut -d: -f1)
+  fetch_line=$(grep -n "fetch origin" "$TEST_TMPDIR/git-calls.log" | head -1 | cut -d: -f1)
+  [ "$remove_line" -lt "$fetch_line" ]
+}
+
+@test "sync 失敗時にフック全体が失敗する" {
+  # fetch が失敗するモック
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "worktree" ]; then
+  if [ "$2" = "remove" ]; then exit 0; fi
+  if [ "$2" = "prune" ]; then exit 0; fi
+fi
+if [ "$1" = "-C" ]; then
+  shift 2
+  case "$1" in
+    config)
+      if [ "$2" = "--get" ]; then
+        echo "+refs/heads/*:refs/remotes/origin/*"
+        exit 0
+      fi
+      ;;
+    fetch) exit 1 ;;
+  esac
+  exit 0
+fi
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run bash "$SCRIPT_PATH" <<< "{\"worktree_path\":\"$MOCK_WORKTREE_PATH\"}"
+
+  [ "$status" -ne 0 ]
+}
+
+@test "worktree が通常リポジトリの場合 sync はスキップされる" {
+  # .git ファイルを削除して .git ディレクトリに変更 (通常リポジトリ)
+  rm "$MOCK_WORKTREE_PATH/.git"
+  mkdir -p "$MOCK_WORKTREE_PATH/.git"
+
+  run bash "$SCRIPT_PATH" <<< "{\"worktree_path\":\"$MOCK_WORKTREE_PATH\"}"
+
+  [ "$status" -eq 0 ]
+  # fetch は呼ばれない (sync スキップ)
+  run ! grep -q "fetch origin" "$TEST_TMPDIR/git-calls.log"
 }


### PR DESCRIPTION
## Summary

- worktree 作成時に `git fetch origin` + `git merge --ff-only` でメインリポジトリを最新に同期してから分岐する
- worktree 削除後にもメインリポジトリを同期し、戻ったときに古い状態で作業を続ける問題を防ぐ
- 共有ライブラリ `sync-main-repo.sh` を新設し、通常リポジトリ・bare リポジトリ両対応

## Changes

| ファイル | 操作 | 目的 |
|---------|------|------|
| `dotclaude/hooks/lib/sync-main-repo.sh` | 新規 | `resolve_main_repo()`, `sync_main_repo()` 共有ライブラリ |
| `dotclaude/hooks/worktree-create.sh` | 変更 | `git wt` 前に sync 呼び出し |
| `dotclaude/hooks/worktree-remove.sh` | 変更 | worktree 削除後に sync 呼び出し |
| `tests/sync-main-repo.bats` | 新規 | ライブラリの単体テスト (19テスト) |
| `tests/worktree-create.bats` | 変更 | sync 連携テスト追加 |
| `tests/worktree-remove.bats` | 変更 | sync 連携テスト追加 |

## Design decisions

- sync の実際の失敗 (fetch, merge, config) は `return 1` でフック全体を失敗させる
- skip 条件 (detached HEAD, feature ブランチ中, デフォルトブランチ不在) は `return 0` (エラーではなく「同期不要」)
- bare リポジトリは `git update-ref` + `merge-base --is-ancestor` で ff-only 相当のチェック

## Test plan

- [x] shellcheck クリーン
- [x] bats テスト 173/173 通過
- [x] Go テスト全通過
- [x] Docker 検証 51/51 通過 (`task docker:verify`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)