### PR TITLE
fix: add timeout and prompt suppression to git fetch in worktree hook

### DIFF
--- a/docker/reproduce-hook-hang.sh
+++ b/docker/reproduce-hook-hang.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+set -euo pipefail
+
+# reproduce-hook-hang.sh
+# worktree-create.sh のハング問題を Docker コンテナ内で再現・診断する
+#
+# テスト条件:
+#   1. remote あり + ネットワーク接続あり (通常環境)
+#   2. remote あり + ネットワーク切断 (--network none)
+#   3. remote なし (resolve_main_repo の fallback)
+
+IMAGE_NAME="claude-config-verify"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STAGING_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-config-reproduce"
+
+usage() {
+  printf '%s\n' "Usage: $(basename "$0") [OPTIONS]"
+  printf '%s\n' ""
+  printf '%s\n' "worktree-create.sh のハング問題を Docker コンテナ内で再現する"
+  printf '%s\n' ""
+  printf '%s\n' "Options:"
+  printf '%s\n' "  --rebuild   Docker イメージを強制再ビルド"
+  printf '%s\n' "  --timeout N SYNC_FETCH_TIMEOUT の秒数を指定 (デフォルト: 5)"
+  printf '%s\n' "  --help      このヘルプを表示"
+}
+
+# オプション解析
+FORCE_REBUILD=false
+FETCH_TIMEOUT=5
+for arg in "$@"; do
+  case "$arg" in
+    --rebuild) FORCE_REBUILD=true ;;
+    --timeout)
+      shift
+      FETCH_TIMEOUT="$1"
+      ;;
+    --help) usage; exit 0 ;;
+  esac
+  shift 2>/dev/null || true
+done
+
+# イメージビルド (verify.sh と同じイメージを使用)
+if [ "$FORCE_REBUILD" = true ] || ! docker image inspect "$IMAGE_NAME" > /dev/null 2>&1; then
+  printf '%s\n' "=== Building Docker image ==="
+  "$REPO_ROOT/docker/verify.sh" --rebuild --check || true
+fi
+
+# hooks をステージングにコピー
+prepare_staging() {
+  rm -rf "$STAGING_DIR"
+  mkdir -p "$STAGING_DIR/hooks/lib"
+  cp "$REPO_ROOT/dotclaude/hooks/worktree-create.sh" "$STAGING_DIR/hooks/"
+  cp "$REPO_ROOT/dotclaude/hooks/lib/hook-logger.sh" "$STAGING_DIR/hooks/lib/"
+  cp "$REPO_ROOT/dotclaude/hooks/lib/sync-main-repo.sh" "$STAGING_DIR/hooks/lib/"
+
+  # worktree-memory-load.sh のスタブ (テストには不要)
+  cat > "$STAGING_DIR/hooks/worktree-memory-load.sh" << 'EOF'
+#!/bin/bash
+exit 0
+EOF
+  chmod +x "$STAGING_DIR/hooks/worktree-memory-load.sh"
+  chmod +x "$STAGING_DIR/hooks/worktree-create.sh"
+}
+
+# コンテナ内で実行するテストスクリプト (変数展開はコンテナ内で行う)
+# shellcheck disable=SC2016
+CONTAINER_SCRIPT='
+set -euo pipefail
+
+FETCH_TIMEOUT="${SYNC_FETCH_TIMEOUT:-5}"
+HOOKS_DIR="/staging/hooks"
+
+printf "%s\n" "=== Test setup ==="
+cd /tmp
+git init test-repo >/dev/null 2>&1
+cd test-repo
+git config user.email "test@test.com"
+git config user.name "test"
+git commit --allow-empty -m "init" >/dev/null 2>&1
+
+setup_remote() {
+  git remote add origin https://github.com/usadamasa/claude-config.git 2>/dev/null || true
+}
+
+remove_remote() {
+  git remote remove origin 2>/dev/null || true
+}
+
+printf "%s\n" ""
+printf "%s\n" "=== Running worktree-create.sh with bash -x ==="
+printf "%s\n" "SYNC_FETCH_TIMEOUT=$FETCH_TIMEOUT"
+printf "%s\n" ""
+
+# git wt は不在なので、sync_main_repo までの動作を確認する
+# worktree-create.sh は git wt がなくても sync 部分は実行される
+
+if [ "${TEST_CONDITION:-}" = "no-remote" ]; then
+  remove_remote
+  printf "%s\n" "--- Condition: no remote ---"
+else
+  setup_remote
+  printf "%s\n" "--- Condition: remote present ---"
+fi
+
+export SCRIPT_DIR="$HOOKS_DIR"
+export SYNC_FETCH_TIMEOUT="$FETCH_TIMEOUT"
+export DRY_RUN=0
+
+printf "%s\n" ""
+printf "%s\n" "--- bash -x trace start ---"
+
+# worktree-create.sh 全体を実行すると git wt が必要になるため、
+# sync 部分のみを直接テストする
+bash -x -c "
+source \"$HOOKS_DIR/lib/hook-logger.sh\"
+source \"$HOOKS_DIR/lib/sync-main-repo.sh\"
+export HOOK_NAME=reproduce-test
+export SYNC_FETCH_TIMEOUT=$FETCH_TIMEOUT
+
+# resolve_main_repo は .git ファイルが必要 (worktree 構造)
+# 通常リポジトリなので resolve は失敗 → CWD をそのまま使用
+MAIN_REPO=\$(resolve_main_repo /tmp/test-repo 2>/dev/null) || MAIN_REPO=\"\"
+if [ -z \"\$MAIN_REPO\" ] && [ -d /tmp/test-repo/.git ]; then
+  MAIN_REPO=/tmp/test-repo
+fi
+printf \"%s\n\" \"MAIN_REPO=\$MAIN_REPO\"
+
+if [ -n \"\$MAIN_REPO\" ]; then
+  sync_main_repo \"\$MAIN_REPO\" && printf \"%s\n\" \"sync: SUCCESS\" || printf \"%s\n\" \"sync: FAILED (exit: \$?)\"
+else
+  printf \"%s\n\" \"sync: SKIPPED (no main repo)\"
+fi
+" 2>&1
+
+printf "%s\n" "--- bash -x trace end ---"
+printf "%s\n" ""
+'
+
+run_test() {
+  local condition="$1"
+  local network_flag="$2"
+  local description="$3"
+
+  printf '%s\n' "=============================================="
+  printf '%s\n' "Test: $description"
+  printf '%s\n' "=============================================="
+
+  local docker_args=(--rm -i
+    --entrypoint bash
+    -v "$STAGING_DIR:/staging:ro"
+    -e "TEST_CONDITION=$condition"
+    -e "SYNC_FETCH_TIMEOUT=$FETCH_TIMEOUT"
+  )
+
+  if [ -n "$network_flag" ]; then
+    docker_args+=("$network_flag")
+  fi
+
+  local exit_code=0
+  timeout 60 docker run "${docker_args[@]}" "$IMAGE_NAME" \
+    -c "$CONTAINER_SCRIPT" 2>&1 || exit_code=$?
+
+  if [ "$exit_code" -eq 124 ]; then
+    printf '%s\n' ""
+    printf '%s\n' "*** RESULT: HUNG (timed out after 60s) ***"
+  elif [ "$exit_code" -eq 0 ]; then
+    printf '%s\n' ""
+    printf '%s\n' "*** RESULT: COMPLETED NORMALLY ***"
+  else
+    printf '%s\n' ""
+    printf '%s\n' "*** RESULT: FAILED (exit: $exit_code) ***"
+  fi
+
+  printf '%s\n' ""
+}
+
+# ステージング準備
+prepare_staging
+
+printf '%s\n' "Docker reproduce-hook-hang.sh"
+printf '%s\n' "SYNC_FETCH_TIMEOUT=${FETCH_TIMEOUT}s"
+printf '%s\n' ""
+
+# Test 1: remote あり + ネットワーク接続あり
+run_test "with-remote" "" "Remote + Network (normal)"
+
+# Test 2: remote あり + ネットワーク切断
+run_test "with-remote" "--network=none" "Remote + No Network (reproduce hang)"
+
+# Test 3: remote なし
+run_test "no-remote" "" "No Remote (fallback)"
+
+printf '%s\n' "=============================================="
+printf '%s\n' "All tests completed"
+printf '%s\n' "=============================================="

--- a/tests/sync-main-repo.bats
+++ b/tests/sync-main-repo.bats
@@ -508,3 +508,127 @@ MOCKEOF
   [[ "$output" == *"already up to date"* ]]
   run ! grep -q "update-ref" "$TEST_TMPDIR/git-calls.log"
 }
+
+# =============================================================================
+# _git_fetch_with_timeout
+# =============================================================================
+
+_run_fetch_with_timeout() {
+  export PATH="$MOCK_BIN:$PATH"
+  # shellcheck disable=SC1091
+  source "$MOCK_BIN/lib/hook-logger.sh"
+  # shellcheck disable=SC1091
+  source "$MOCK_BIN/lib/sync-main-repo.sh"
+  _git_fetch_with_timeout "$@"
+}
+
+@test "_git_fetch_with_timeout: 正常系 - fetch 成功" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+# fetch 成功
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_fetch_with_timeout "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 0 ]
+  grep -q "fetch origin" "$TEST_TMPDIR/git-calls.log"
+}
+
+@test "_git_fetch_with_timeout: fetch 失敗時は非ゼロ終了" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+exit 1
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_fetch_with_timeout "$TEST_PARENT_REPO"
+
+  [ "$status" -ne 0 ]
+}
+
+@test "_git_fetch_with_timeout: GIT_TERMINAL_PROMPT=0 が設定される" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "GIT_TERMINAL_PROMPT=$GIT_TERMINAL_PROMPT" >> "$TEST_TMPDIR/git-env.log"
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_fetch_with_timeout "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 0 ]
+  grep -q "GIT_TERMINAL_PROMPT=0" "$TEST_TMPDIR/git-env.log"
+}
+
+@test "_git_fetch_with_timeout: SYNC_FETCH_TIMEOUT で秒数を指定できる" {
+  # timeout コマンドのモックで引数を記録
+  cat > "$MOCK_BIN/timeout" << 'MOCKEOF'
+#!/bin/bash
+echo "timeout_args=$*" >> "$TEST_TMPDIR/timeout-calls.log"
+# 引数をシフトしてコマンドを実行
+shift  # timeout seconds
+"$@"
+MOCKEOF
+  chmod +x "$MOCK_BIN/timeout"
+
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  export SYNC_FETCH_TIMEOUT=5
+  run _run_fetch_with_timeout "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 0 ]
+  grep -q "timeout_args=5" "$TEST_TMPDIR/timeout-calls.log"
+}
+
+@test "_git_fetch_with_timeout: timeout コマンド不在時はタイムアウトなしで fetch" {
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  # timeout コマンドを無効化: MOCK_BIN + /usr/bin のみ (timeout は /usr/local/bin や /opt/homebrew/bin)
+  export PATH="$MOCK_BIN:/usr/bin:/bin"
+  run _run_fetch_with_timeout "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 0 ]
+  grep -q "fetch origin" "$TEST_TMPDIR/git-calls.log"
+}
+
+@test "sync_main_repo: fetch タイムアウト時は return 1 でエラーメッセージ出力" {
+  # timeout コマンドのモック: exit 124 (タイムアウト)
+  cat > "$MOCK_BIN/timeout" << 'MOCKEOF'
+#!/bin/bash
+exit 124
+MOCKEOF
+  chmod +x "$MOCK_BIN/timeout"
+
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "$@" >> "$TEST_TMPDIR/git-calls.log"
+if [ "$1" = "-C" ]; then shift 2; fi
+case "$1" in
+  config)
+    if [ "$2" = "--get" ]; then
+      echo "+refs/heads/*:refs/remotes/origin/*"
+      exit 0
+    fi
+    ;;
+esac
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  run _run_sync "$TEST_PARENT_REPO"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"fetch timed out"* ]]
+}


### PR DESCRIPTION
## Summary
- Add `_git_fetch_with_timeout()` to `sync-main-repo.sh` with `GIT_TERMINAL_PROMPT=0` and configurable timeout (`SYNC_FETCH_TIMEOUT`, default 30s) to prevent worktree-create hook from hanging
- Replace bare `git fetch` call with timeout-protected version that distinguishes timeout (exit 124) from other failures
- Add Docker reproduction script (`docker/reproduce-hook-hang.sh`) to diagnose hang under 3 network conditions

## Test plan
- [x] 6 new bats tests for `_git_fetch_with_timeout` (normal, failure, GIT_TERMINAL_PROMPT, custom timeout, no-timeout fallback, timeout error message)
- [x] All 179 existing bats tests pass unchanged
- [x] Go tests pass
- [x] shellcheck passes
- [x] Docker reproduction confirms fetch returns immediately under `--network none` instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)