### PR TITLE
fix: add missing dotclaude/bin symlink to setup task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Claude Code のグローバル設定を構成管理するリポジトリ｡
 | `dotclaude/settings.json` | パーミッション・モデル設定 (→ `~/.claude/settings.json`) |
 | `dotclaude/env.sh` | 環境変数設定 (→ `~/.claude/env.sh`) |
 | `dotclaude/hooks/` | セッションフック (→ `~/.claude/hooks/`) |
+| `dotclaude/bin/` | フック用 Go バイナリ (→ `~/.claude/bin/`) |
 | `dotclaude/skills/` | グローバルスキル (各サブディレクトリ → `~/.claude/skills/`) |
 | `CLAUDE.md` | このファイル (プロジェクトスコープ) |
 | `cmd/` | Go CLI ツール (詳細は `cmd/CLAUDE.md`) |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -76,7 +76,7 @@ tasks:
         done
       # dotclaude/ 配下のディレクトリの symlink
       - |
-        for dir in dotclaude/hooks; do
+        for dir in dotclaude/hooks dotclaude/bin; do
           if [ -d "{{.TASKFILE_DIR}}/$dir" ]; then
             basename=$(basename "$dir")
             target="$HOME/.claude/$basename"
@@ -111,6 +111,7 @@ tasks:
         echo "  CLAUDE.md (← CLAUDE-global.md): $(test -L "$HOME/.claude/CLAUDE.md" && echo '✓' || echo '✗')"
         echo "  settings.json: $(test -L "$HOME/.claude/settings.json" && echo '✓' || echo '✗')"
         echo "  hooks: $(test -L "$HOME/.claude/hooks" && echo '✓' || echo '✗')"
+        echo "  bin: $(test -L "$HOME/.claude/bin" && echo '✓' || echo '✗')"
         echo "  env.sh: $(test -L "$HOME/.claude/env.sh" && echo '✓' || echo '✗')"
         echo "  skills:"
         for skill_dir in "{{.TASKFILE_DIR}}/dotclaude/skills"/*/; do
@@ -124,12 +125,14 @@ tasks:
     cmds:
       - rm -f "$HOME/.claude/CLAUDE.md" "$HOME/.claude/settings.json" "$HOME/.claude/env.sh"
       - |
-        target="$HOME/.claude/hooks"
-        if [ -L "$target" ]; then
-          rm -f "$target"
-        elif [ -d "$target" ]; then
-          rm -rf "$target"
-        fi
+        for dir in hooks bin; do
+          target="$HOME/.claude/$dir"
+          if [ -L "$target" ]; then
+            rm -f "$target"
+          elif [ -d "$target" ]; then
+            rm -rf "$target"
+          fi
+        done
       - |
         for skill_dir in "{{.TASKFILE_DIR}}/dotclaude/skills"/*/; do
           [ -d "$skill_dir" ] || continue


### PR DESCRIPTION
## Summary
- `task setup` で `dotclaude/bin/` → `~/.claude/bin/` の symlink が作成されておらず、`guard-home-dir` フックが機能していなかった問題を修正
- `setup`、`status`、`clean` タスクに `dotclaude/bin/` の対応を追加
- CLAUDE.md のディレクトリ構成テーブルに `dotclaude/bin/` を追記

## Test plan
- [x] Go ユニットテスト全パス
- [x] bats 統合テスト 28/28 パス
- [x] `task setup` で `bin/` symlink が作成されることを確認
- [x] `task status` で `bin: ✓` が表示されることを確認
- [x] symlink 経由で guard-home-dir の deny/allow が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)