### PR TITLE
fix: support subdirectory go.mod layout in go-arch-metrics skill

### DIFF
--- a/dotclaude/skills/go-arch-metrics/references/ci-integration.md
+++ b/dotclaude/skills/go-arch-metrics/references/ci-integration.md
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: go.mod  # go.mod がサブディレクトリにある場合: go-version-file: cmd/go.mod
           cache: true
 
       - name: Setup aqua
@@ -87,7 +87,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: go.mod  # go.mod がサブディレクトリにある場合: go-version-file: cmd/go.mod
           cache: true
 
       - name: Setup aqua
@@ -122,7 +122,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: go.mod  # go.mod がサブディレクトリにある場合: go-version-file: cmd/go.mod
           cache: false
 
       - name: golangci-lint
@@ -147,6 +147,40 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: false
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - uses: aquaproj/aqua-installer@v3
+        with:
+          aqua_version: v2.53.3
+
+      - name: govulncheck
+        run: govulncheck ./...
+
+      - name: gosec
+        run: gosec ./...
+```
+
+### サブディレクトリ構成の場合
+
+`go.mod` がリポジトリルート直下ではなくサブディレクトリ (例: `cmd/`) にある場合は、
+`defaults.run.working-directory` と `go-version-file` を調整する:
+
+```yaml
+  security-scan:
+    name: Security scan
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cmd
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cmd/go.mod
           cache: false
 
       - name: Install govulncheck

--- a/dotclaude/skills/go-arch-metrics/scripts/baseline.sh
+++ b/dotclaude/skills/go-arch-metrics/scripts/baseline.sh
@@ -14,7 +14,19 @@ if [[ ! -d "$PROJECT_ROOT" ]]; then
 fi
 
 if [[ ! -f "${PROJECT_ROOT}/go.mod" ]]; then
-    echo "エラー: go.mod が見つかりません。Go プロジェクトルートを指定してください: $PROJECT_ROOT" >&2
+    # サブディレクトリに go.mod があるか検索
+    FOUND_MODS=$(find "$PROJECT_ROOT" -maxdepth 2 -name "go.mod" -not -path "*/vendor/*" 2>/dev/null)
+    if [[ -n "$FOUND_MODS" ]]; then
+        printf '%s\n' "エラー: ${PROJECT_ROOT}/go.mod が見つかりません。" >&2
+        printf '%s\n' "以下のサブディレクトリに go.mod があります:" >&2
+        echo "$FOUND_MODS" | while read -r f; do
+            printf '  %s\n' "$(dirname "$f")" >&2
+        done
+        FIRST_MOD=$(echo "$FOUND_MODS" | head -1)
+        printf '%s\n' "使用方法: baseline.sh $(dirname "$FIRST_MOD")" >&2
+    else
+        printf '%s\n' "エラー: go.mod が見つかりません。Go プロジェクトルートを指定してください: $PROJECT_ROOT" >&2
+    fi
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- CI integration guide (`ci-integration.md`) にサブディレクトリ構成の Go プロジェクト向けパターンを追記
  - `go-version-file` の3箇所にインラインコメントで `cmd/go.mod` パターンを補足
  - セキュリティスキャンジョブに `defaults.run.working-directory` を使った完全な例を追加
- `baseline.sh` で `go.mod` がルートにない場合にサブディレクトリを検索し候補を提示するよう改善

## Background

PR #45 で Go module が `cmd/` サブディレクトリに移動したが、go-arch-metrics スキルのリファレンスが旧レイアウト前提のまま残っていた (PR #43 Copilot レビュー指摘)。

## Test plan

- [x] `task test` — bats 177件 + Go テスト全パス
- [x] `shellcheck baseline.sh` — lint エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)