### PR TITLE
fix: bump Go version to 1.25.8 to resolve stdlib vulnerabilities

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -1,3 +1,3 @@
 module github.com/usadamasa/claude-config
 
-go 1.25
+go 1.25.8


### PR DESCRIPTION
## Summary
- Go 1.25 → 1.25.8 にバージョンを更新し、標準ライブラリの脆弱性を解消
- **GO-2026-4602**: `os.ReadDir` の FileInfo が Root からエスケープできる脆弱性
- **GO-2026-4601**: `net/url.Parse` の IPv6 ホストリテラル解析の不正

## Changes
- `cmd/go.mod`: `go 1.25` → `go 1.25.8`

## Test plan
- [ ] CI の `govulncheck` ジョブが通ることを確認
- [ ] `go vet ./...` でビルドエラーがないことを確認 (ローカルで確認済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)