### PR TITLE
fix: correct go run paths in skill files for cmd/go.mod

### DIFF
--- a/.claude/skills/permission-optimizer/SKILL.md
+++ b/.claude/skills/permission-optimizer/SKILL.md
@@ -47,7 +47,7 @@ fi
 
 CLI を実行:
 ```bash
-go run ./cmd/analyze-permissions --days 30 --settings "$SETTINGS_PATH" --projects-dir ~/.claude/projects
+cd cmd && go run ./analyze-permissions --days 30 --settings "$SETTINGS_PATH" --projects-dir ~/.claude/projects
 ```
 
 フル JSON が必要な場合は `--format json --output /tmp/report.json` を追加する。

--- a/.claude/skills/token-usage-analyzer/SKILL.md
+++ b/.claude/skills/token-usage-analyzer/SKILL.md
@@ -10,18 +10,20 @@ description: |
 
 ## CLIツールの実行
 
+`go.mod` は `cmd/` ディレクトリにあるため、claude-config リポジトリルートから `cd cmd &&` を付けて実行する。
+
 ```bash
 # 直近30日間の分析(デフォルト)
-go run ~/src/github.com/usadamasa/dotfile/main/cmd/analyze-tokens
+cd cmd && go run ./analyze-tokens
 
 # 期間指定
-go run ~/src/github.com/usadamasa/dotfile/main/cmd/analyze-tokens --days 7
+cd cmd && go run ./analyze-tokens --days 7
 
 # Top N変更
-go run ~/src/github.com/usadamasa/dotfile/main/cmd/analyze-tokens --top 20
+cd cmd && go run ./analyze-tokens --top 20
 
 # カスタムディレクトリ指定
-go run ~/src/github.com/usadamasa/dotfile/main/cmd/analyze-tokens --dir ~/.claude/projects
+cd cmd && go run ./analyze-tokens --dir ~/.claude/projects
 ```
 
 ## 出力フォーマット
@@ -79,7 +81,7 @@ JSON形式で以下のセクションを出力する:
 
 月1回、以下の手順で分析を実施する:
 
-1. `go run ~/src/github.com/usadamasa/dotfile/main/cmd/analyze-tokens --days 30` を実行
+1. `cd cmd && go run ./analyze-tokens --days 30` を実行
 2. average_input_per_call の推移を確認
 3. 未使用プラグインやスキルがあれば無効化/移動
 4. 結果を前月と比較し、改善効果を確認

--- a/.claude/skills/webfetch-domain-manager/SKILL.md
+++ b/.claude/skills/webfetch-domain-manager/SKILL.md
@@ -25,12 +25,12 @@ worktree 環境の場合、以降のステップで settings.json のパスを `
 
 **通常リポジトリ:**
 ```bash
-go run ./cmd/analyze-webfetch --days 30
+cd cmd && go run ./analyze-webfetch --days 30
 ```
 
 **worktree 環境:**
 ```bash
-go run ./cmd/analyze-webfetch --days 30 --settings $(pwd)/dotclaude/settings.json --projects-dir ~/.claude/projects
+REPO_ROOT=$(pwd) && cd cmd && go run ./analyze-webfetch --days 30 --settings "$REPO_ROOT/dotclaude/settings.json" --projects-dir ~/.claude/projects
 ```
 
 オプション:


### PR DESCRIPTION
## Summary

- Fixed `go run` paths in all 3 CLI skill files to account for `go.mod` being in `cmd/`, not the repo root
- Replaced `go run ./cmd/analyze-*` with `cd cmd && go run ./analyze-*` across permission-optimizer, webfetch-domain-manager, and token-usage-analyzer
- Fixed token-usage-analyzer's legacy `~/src/github.com/usadamasa/dotfile/main/cmd/` paths
- Fixed webfetch-domain-manager's `$(pwd)` expansion issue after `cd cmd` by saving `REPO_ROOT` beforehand

## Test plan

- [x] `grep -r "dotfile" .claude/skills/` returns no matches
- [x] `grep "go run ./cmd/" .claude/skills/` returns no matches
- [x] `cd cmd && go run ./analyze-tokens --days 1` runs successfully
- [x] `cd cmd && go run ./analyze-webfetch --days 1` runs successfully
- [x] `cd cmd && go run ./analyze-permissions --days 1 --settings ...` runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)