### PR TITLE
feat: add ralph-loop custom skill and Stop hook

### DIFF
--- a/dotclaude/hooks/ralph-loop-stop.sh
+++ b/dotclaude/hooks/ralph-loop-stop.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+# Ralph Loop Stop Hook
+# Prevents session exit when a ralph-loop is active
+# Feeds Claude's output back as input to continue the loop
+
+set -euo pipefail
+
+# Read hook input from stdin (advanced stop hook API)
+HOOK_INPUT=$(cat)
+
+# Resolve project root (works in both normal repo and worktree)
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+
+# Check if ralph-loop is active
+RALPH_STATE_FILE="$PROJECT_ROOT/tmp/ralph-loop.local.md"
+
+if [[ ! -f "$RALPH_STATE_FILE" ]]; then
+  # No active loop - allow exit
+  exit 0
+fi
+
+# Parse markdown frontmatter (YAML between ---) and extract values
+FRONTMATTER=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$RALPH_STATE_FILE")
+ITERATION=$(printf '%s\n' "$FRONTMATTER" | grep '^iteration:' | sed 's/iteration: *//')
+MAX_ITERATIONS=$(printf '%s\n' "$FRONTMATTER" | grep '^max_iterations:' | sed 's/max_iterations: *//')
+# Extract completion_promise and strip surrounding quotes if present
+COMPLETION_PROMISE=$(printf '%s\n' "$FRONTMATTER" | grep '^completion_promise:' | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/')
+
+# Session isolation: the state file is project-scoped, but the Stop hook
+# fires in every Claude Code session in that project. If another session
+# started the loop, this session must not block (or touch the state file).
+# Legacy state files without session_id fall through (preserves old behavior).
+STATE_SESSION=$(printf '%s\n' "$FRONTMATTER" | grep '^session_id:' | sed 's/session_id: *//' || true)
+HOOK_SESSION=$(printf '%s\n' "$HOOK_INPUT" | jq -r '.session_id // ""')
+if [[ -n "$STATE_SESSION" ]] && [[ "$STATE_SESSION" != "$HOOK_SESSION" ]]; then
+  exit 0
+fi
+
+# Validate numeric fields before arithmetic operations
+if [[ ! "$ITERATION" =~ ^[0-9]+$ ]]; then
+  printf '%s\n' "Warning: Ralph loop state file corrupted (iteration: '$ITERATION'). Stopping." >&2
+  rm "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+if [[ ! "$MAX_ITERATIONS" =~ ^[0-9]+$ ]]; then
+  printf '%s\n' "Warning: Ralph loop state file corrupted (max_iterations: '$MAX_ITERATIONS'). Stopping." >&2
+  rm "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+# Check if max iterations reached
+if [[ $MAX_ITERATIONS -gt 0 ]] && [[ $ITERATION -ge $MAX_ITERATIONS ]]; then
+  printf '%s\n' "Ralph loop: Max iterations ($MAX_ITERATIONS) reached."
+  rm "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+# Get transcript path from hook input
+TRANSCRIPT_PATH=$(printf '%s\n' "$HOOK_INPUT" | jq -r '.transcript_path')
+
+if [[ ! -f "$TRANSCRIPT_PATH" ]]; then
+  printf '%s\n' "Warning: Ralph loop transcript not found ($TRANSCRIPT_PATH). Stopping." >&2
+  rm "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+# Read last assistant message from transcript (JSONL format - one JSON per line)
+if ! grep -q '"role":"assistant"' "$TRANSCRIPT_PATH"; then
+  printf '%s\n' "Warning: No assistant messages in transcript. Stopping." >&2
+  rm "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+# Extract the most recent assistant text block.
+# Capped at the last 100 assistant lines to keep jq's slurp input bounded.
+LAST_LINES=$(grep '"role":"assistant"' "$TRANSCRIPT_PATH" | tail -n 100)
+if [[ -z "$LAST_LINES" ]]; then
+  printf '%s\n' "Warning: Failed to extract assistant messages. Stopping." >&2
+  rm "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+# Parse the recent lines and pull out the final text block.
+set +e
+LAST_OUTPUT=$(printf '%s\n' "$LAST_LINES" | jq -rs '
+  map(.message.content[]? | select(.type == "text") | .text) | last // ""
+' 2>&1)
+JQ_EXIT=$?
+set -e
+
+if [[ $JQ_EXIT -ne 0 ]]; then
+  printf '%s\n' "Warning: Failed to parse assistant message JSON. Stopping." >&2
+  printf '%s\n' "  Error: $LAST_OUTPUT" >&2
+  rm "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+# Check for completion promise (only if set)
+if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
+  # Extract text from <promise> tags using Perl for multiline support
+  PROMISE_TEXT=$(printf '%s\n' "$LAST_OUTPUT" | perl -0777 -pe 's/.*?<promise>(.*?)<\/promise>.*/$1/s; s/^\s+|\s+$//g; s/\s+/ /g' 2>/dev/null || true)
+
+  # Use = for literal string comparison (not pattern matching)
+  if [[ -n "$PROMISE_TEXT" ]] && [[ "$PROMISE_TEXT" = "$COMPLETION_PROMISE" ]]; then
+    printf '%s\n' "Ralph loop: Detected <promise>$COMPLETION_PROMISE</promise>"
+    rm "$RALPH_STATE_FILE"
+    exit 0
+  fi
+fi
+
+# Not complete - continue loop with SAME PROMPT
+NEXT_ITERATION=$((ITERATION + 1))
+
+# Extract prompt (everything after the closing ---)
+PROMPT_TEXT=$(awk '/^---$/{i++; next} i>=2' "$RALPH_STATE_FILE")
+
+if [[ -z "$PROMPT_TEXT" ]]; then
+  printf '%s\n' "Warning: No prompt text found in state file. Stopping." >&2
+  rm "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+# Update iteration in frontmatter (portable across macOS and Linux)
+TEMP_FILE="${RALPH_STATE_FILE}.tmp.$$"
+sed "s/^iteration: .*/iteration: $NEXT_ITERATION/" "$RALPH_STATE_FILE" > "$TEMP_FILE"
+mv "$TEMP_FILE" "$RALPH_STATE_FILE"
+
+# Build system message with iteration count and completion promise info
+if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
+  SYSTEM_MSG="Ralph iteration $NEXT_ITERATION | To stop: output <promise>$COMPLETION_PROMISE</promise> (ONLY when statement is TRUE)"
+else
+  SYSTEM_MSG="Ralph iteration $NEXT_ITERATION | No completion promise set - loop runs until max iterations"
+fi
+
+# Output JSON to block the stop and feed prompt back
+jq -n \
+  --arg prompt "$PROMPT_TEXT" \
+  --arg msg "$SYSTEM_MSG" \
+  '{
+    "decision": "block",
+    "reason": $prompt,
+    "systemMessage": $msg
+  }'
+
+exit 0

--- a/dotclaude/settings.json
+++ b/dotclaude/settings.json
@@ -23,7 +23,6 @@
     "playwright@claude-plugins-official": false,
     "plugin-dev@claude-plugins-official": false,
     "pr-review-toolkit@claude-plugins-official": true,
-    "ralph-loop@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
     "superpowers@claude-plugins-official": true,
@@ -68,6 +67,16 @@
           {
             "type": "command",
             "command": "$HOME/.claude/hooks/guard-git-commit-main.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/ralph-loop-stop.sh"
           }
         ]
       }

--- a/dotclaude/skills/ralph-cancel/SKILL.md
+++ b/dotclaude/skills/ralph-cancel/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: ralph-cancel
+description: >
+  アクティブな Ralph Loop をキャンセルする。
+  状態ファイルを削除してループを停止する。
+---
+
+# Ralph Cancel コマンド
+
+## 手順
+
+1. Bash で `tmp/ralph-loop.local.md` の存在を確認する:
+   ```
+   test -f tmp/ralph-loop.local.md && echo "EXISTS" || echo "NOT_FOUND"
+   ```
+
+2. **NOT_FOUND の場合**: 「アクティブな Ralph loop はありません。」と報告する
+
+3. **EXISTS の場合**:
+   - Read ツールで `tmp/ralph-loop.local.md` を読み、`iteration:` フィールドの値を取得する
+   - Bash で状態ファイルを削除する: `rm tmp/ralph-loop.local.md`
+   - 「Ralph loop をキャンセルしました (イテレーション N で停止)」と報告する (N は iteration の値)

--- a/dotclaude/skills/ralph-loop/SKILL.md
+++ b/dotclaude/skills/ralph-loop/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: ralph-loop
+description: >
+  現在のセッションで Ralph Loop を開始する。
+  反復的な開発ループにより、同じプロンプトを繰り返しフィードして自己改善を行う。
+  複数行プロンプトに対応。
+argument-hint: "PROMPT [--max-iterations N] [--completion-promise TEXT]"
+---
+
+# Ralph Loop コマンド
+
+## 引数のパース
+
+`$ARGUMENTS` を以下のルールで解析する (シェルに渡さないこと):
+
+1. `--max-iterations N` があれば N を抽出する (デフォルト: 0 = 無制限)
+2. `--completion-promise TEXT` があれば TEXT を抽出する (デフォルト: null)
+3. 残りすべてがプロンプト本文
+
+プロンプトが空の場合はエラーメッセージを出して終了する。
+
+## 状態ファイルの作成
+
+1. Bash で `mkdir -p tmp` を実行する
+2. Write ツールで `tmp/ralph-loop.local.md` を以下の形式で作成する:
+
+```
+---
+active: true
+iteration: 1
+session_id: (Bash で `echo $CLAUDE_CODE_SESSION_ID` を実行して取得)
+max_iterations: <パースした値>
+completion_promise: "<パースした値>" (null の場合は null)
+started_at: "<現在のUTC時刻 ISO8601>"
+---
+
+<プロンプト本文 (複数行OK)>
+```
+
+**重要**: Write ツールを使うことで、複数行プロンプトがそのまま安全に書き込まれる。
+
+## セットアップメッセージ
+
+状態ファイル作成後、以下を出力する:
+
+```
+Ralph loop activated in this session!
+
+Iteration: 1
+Max iterations: <N or unlimited>
+Completion promise: <TEXT or none>
+```
+
+## タスク実行
+
+セットアップ後、プロンプトの内容に取り掛かる。
+
+## 重要なルール
+
+- **completion promise が設定されている場合**: `<promise>TEXT</promise>` タグは、その内容が完全かつ明白に TRUE であるときのみ出力すること
+- ループを抜けるために嘘の promise を出力してはならない
+- 行き詰まったと感じても、promise が真になるまでループを続けること
+
+## 関連コマンド
+
+- `/ralph-cancel` - アクティブなループをキャンセルする
+- `/ralph-loop-help` - Ralph Loop の詳しい説明を表示する


### PR DESCRIPTION
## Summary

- `ralph-loop` プラグインをカスタムスキル実装に置き換え
- `ralph-loop` / `ralph-cancel` スキルを追加（反復開発ループの開始・キャンセル）
- `Stop` フック (`ralph-loop-stop.sh`) を追加し、セッション終了時にループ状態ファイルをクリーンアップ
- settings.json から `ralph-loop` プラグインを削除し、`Stop` フックを登録

## Test plan

- [x] `task setup` で symlink が正常に作成されること
- [x] `/skills` で `ralph-loop` と `ralph-cancel` が表示されること
- [x] ralph-loop スキルでループが開始・停止できること
- [x] セッション終了時に Stop フックが状態ファイルを削除すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)